### PR TITLE
MODFISTO-23 Define and implement group API

### DIFF
--- a/src/main/java/org/folio/rest/impl/GroupAPI.java
+++ b/src/main/java/org/folio/rest/impl/GroupAPI.java
@@ -16,7 +16,7 @@ import io.vertx.core.Handler;
 
 public class GroupAPI implements FinanceStorageGroups {
 
-  private static final String GROUPS_TABLE = "group";
+  private static final String GROUPS_TABLE = "groups";
 
   @Override
   @Validate

--- a/src/main/resources/templates/db_scripts/schema.json
+++ b/src/main/resources/templates/db_scripts/schema.json
@@ -203,7 +203,7 @@
       ]
     },
     {
-      "tableName": "group",
+      "tableName": "groups",
       "fromModuleVersion": 3.0,
       "withMetadata": true,
       "ginIndex": [

--- a/src/test/java/org/folio/rest/impl/FundsTest.java
+++ b/src/test/java/org/folio/rest/impl/FundsTest.java
@@ -53,7 +53,8 @@ public class FundsTest extends TestBase {
     testAllFieldsExists(responseJson, sampleJson);
 
     logger.info(String.format("--- %s test: Verifying only 1 record was created ... ", testEntity.name()));
-    verifyCollectionQuantity(testEntity.getEndpoint(),1);
+    String endpoint = testEntity.getEndpoint() + "?query=cql.allRecords=1 sortBy " + testEntity.getUpdatedFieldName();
+    verifyCollectionQuantity(endpoint,1);
 
     logger.info(String.format("--- %s test: Fetching record with ID: %s", testEntity.name(), sampleId));
     response = testEntitySuccessfullyFetched(testEntity.getEndpoint(), sampleId);


### PR DESCRIPTION
## Purpose
[MODFISTO-23](https://issues.folio.org/browse/MODFISTO-23) Define and implement group API

## Approach
Rename `group` DB table to `groups` due to ParseException because `GROUP` is sql keyword and constructions like `group.jsonb` are invalid
<details>
<summary>Exception - click to expand</summary>

```
...
PostgresClient  parseQuery SELECT jsonb,id FROM diku_mod_finance_storage.group  WHERE to_tsvector('simple', f_unaccent(group.jsonb->>'name')) @@ replace((to_tsquery('simple', f_unaccent('''a''')))::text, '&', '<->')::tsquery LIMIT 10 OFFSET 0
...
Caused by: net.sf.jsqlparser.parser.ParseException: Encountered " "." ". "" at line 1, column 46.
Was expecting one of:
    <EOF> 
    "AS" ...
    "DO" ...
    "ANY" ...
    "KEY" ...
    "PERCENT" ...
    "END" ...
    "JOIN" ...
    "LEFT" ...
    "CROSS" ...
    "OPEN" ...
    "FULL" ...
    "TABLE" ...
    "WHERE" ...
    "FOR" ...
    "PIVOT" ...
    "XML" ...
    "UNION" ...
    "GROUP" ...
    "INNER" ...
    "ORDER" ...
    "RIGHT" ...
    "VALUE" ...
    "HAVING" ...
    "INSERT" ...
    "VALUES" ...
    "NATURAL" ...
    "REPLACE" ...
    "TRUNCATE" ...
    "INTERSECT" ...
    "CAST" ...
    "EXCEPT" ...
    "MINUS" ...
    "OVER" ...
    "PARTITION" ...
    "EXTRACT" ...
    "MATERIALIZED" ...
    "START" ...
    "CONNECT" ...
    "PRIOR" ...
    "SIBLINGS" ...
    "COLUMN" ...
    "NULLS" ...
    "FIRST" ...
    "LAST" ...
    "ROWS" ...
    "RANGE" ...
    "FOLLOWING" ...
    "ROW" ...
    "COMMIT" ...
    "SEPARATOR" ...
    "CASCADE" ...
    "NO" ...
    "ACTION" ...
    <K_DATETIMELITERAL> ...
    "PRECISION" ...
    ";" ...
    <S_IDENTIFIER> ...
    <S_QUOTED_IDENTIFIER> ...
    "," ...
    "ORDER" ...
    "ORDER" ...
```
</details>

## Pre-Merge Checklist
Before merging this PR, please go through the following list and take appropriate actions.

- Does this PR meet or exceed the expected quality standards?
  - [x] Code coverage on new code is 80% or greater
  - [x] Duplications on new code is 3% or less
  - [x] There are no major code smells or security issues
- Does this introduce breaking changes?
  - [ ] Were any API paths or methods changed, added or removed?
  - [ ] Were there any schema changes?
  - [ ] Did any of the interface versions change?
  - [ ] Were permissions changed, added, or removed?
  - [ ] Are there new interface dependencies?
  - [x] There are no breaking changes in this PR.
