### PR TITLE
MODFISTO-31 Support for querying Budget API by fund/ledger/fiscalYear fields

### DIFF
--- a/src/main/resources/data/budgets/SLAVHIST-FY18.json
+++ b/src/main/resources/data/budgets/SLAVHIST-FY18.json
@@ -1,6 +1,6 @@
 {
   "id": "a7c63802-4c1a-4646-9392-024e08df9c02",
-  "name": "SLAVHIST-FY19",
+  "name": "SLAVHIST-FY18",
   "budgetStatus": "Active",
   "allowableEncumbrance": 110,
   "allowableExpenditure": 100,
@@ -11,5 +11,5 @@
   "expenditures": 1337.13,
   "overEncumbrance": 0,
   "fundId": "f31a36de-fcf8-44f9-87ef-a55d06ad21ae",
-  "fiscalYearId": "684b5dc5-92f6-4db7-b996-b549d88f5e4e"
+  "fiscalYearId": "8da275b8-e099-49a1-9a31-b8241ff26ffc"
 }

--- a/src/main/resources/data/budgets/STATE-MONOSER-FY18.json
+++ b/src/main/resources/data/budgets/STATE-MONOSER-FY18.json
@@ -1,6 +1,6 @@
 {
   "id": "0916fde2-7a7d-4ff0-9069-37ee1ec0c068",
-  "name": "GIFTS-ONE-TIME-FY18",
+  "name": "STATE-MONOSER-FY18",
   "budgetStatus": "Active",
   "allowableEncumbrance": 100,
   "allowableExpenditure": 100,
@@ -11,5 +11,5 @@
   "expenditures": 3780.00,
   "overEncumbrance": 0,
   "fundId": "bbd4a5e1-c9f3-44b9-bfdf-d184e04f0ba0",
-  "fiscalYearId": "684b5dc5-92f6-4db7-b996-b549d88f5e4e"
+  "fiscalYearId": "8da275b8-e099-49a1-9a31-b8241ff26ffc"
 }

--- a/src/main/resources/data/budgets/STATE-SUBN-FY18.json
+++ b/src/main/resources/data/budgets/STATE-SUBN-FY18.json
@@ -1,6 +1,6 @@
 {
   "id": "64a71a11-9143-4ebe-ac3a-b0ced57636ba",
-  "name": "GIFTS-ONE-TIME-FY17",
+  "name": "STATE-SUBN-FY18",
   "budgetStatus": "Active",
   "allowableEncumbrance": 100,
   "allowableExpenditure": 100,
@@ -11,5 +11,5 @@
   "expenditures": 24300.00,
   "overEncumbrance": 0,
   "fundId": "e54b1f4d-7d05-4b1a-9368-3c36b75d8ac6",
-  "fiscalYearId": "684b5dc5-92f6-4db7-b996-b549d88f5e4e"
+  "fiscalYearId": "8da275b8-e099-49a1-9a31-b8241ff26ffc"
 }

--- a/src/main/resources/templates/db_scripts/schema.json
+++ b/src/main/resources/templates/db_scripts/schema.json
@@ -37,6 +37,8 @@
         {
           "fieldName": "ledgerId",
           "targetTable": "ledger",
+          "tableAlias": "fund",
+          "targetTableAlias": "ledger",
           "tOps": "ADD"
         },
         {
@@ -121,11 +123,21 @@
         {
           "fieldName": "fundId",
           "targetTable": "fund",
+          "tableAlias": "budget",
+          "targetTableAlias": "fund",
           "tOps": "ADD"
+        },
+        {
+          "targetPath": ["fundId", "ledgerId"],
+          "targetTable":      "ledger",
+          "targetTableAlias": "ledger",
+          "tableAlias": "budget"
         },
         {
           "fieldName": "fiscalYearId",
           "targetTable": "fiscal_year",
+          "tableAlias": "budget",
+          "targetTableAlias": "fiscalYear",
           "tOps": "ADD"
         }
       ],

--- a/src/test/java/org/folio/rest/impl/BudgetTest.java
+++ b/src/test/java/org/folio/rest/impl/BudgetTest.java
@@ -1,0 +1,40 @@
+package org.folio.rest.impl;
+
+import static org.folio.rest.RestVerticle.OKAPI_HEADER_TENANT;
+import static org.folio.rest.utils.TenantApiTestUtil.deleteTenant;
+import static org.folio.rest.utils.TenantApiTestUtil.prepareTenant;
+
+import java.net.MalformedURLException;
+
+import org.folio.rest.utils.TestEntities;
+import org.junit.Test;
+
+import io.restassured.http.Header;
+
+public class BudgetTest extends TestBase {
+
+  private static final String BUDGET_ENDPOINT = TestEntities.BUDGET.getEndpoint();
+  private static final String BUDGET_TEST_TENANT = "budget_test_tenant";
+  private static final Header BUDGET_TENANT_HEADER = new Header(OKAPI_HEADER_TENANT, BUDGET_TEST_TENANT);
+
+  @Test
+  public void testGetQuery() throws MalformedURLException {
+    prepareTenant(BUDGET_TENANT_HEADER, true);
+
+    // search for GET
+    verifyCollectionQuantity(BUDGET_ENDPOINT, 21, BUDGET_TENANT_HEADER);
+
+    // search with fields from "fund"
+    verifyCollectionQuantity(BUDGET_ENDPOINT + "?query=fund.fundStatus==Inactive", 2, BUDGET_TENANT_HEADER);
+    // search with fields from "FY"
+    verifyCollectionQuantity(BUDGET_ENDPOINT + "?query=fiscalYear.name==FY18", 3, BUDGET_TENANT_HEADER);
+    // search with fields from "ledgers"
+    verifyCollectionQuantity(BUDGET_ENDPOINT + "?query=ledger.name==Ongoing", 7, BUDGET_TENANT_HEADER);
+    // complex query
+    verifyCollectionQuantity(BUDGET_ENDPOINT + "?query=fund.fundStatus==Active AND ledger.name==Ongoing AND fiscalYear.code==FY19", 4, BUDGET_TENANT_HEADER);
+
+    // search with invalid cql query
+    testInvalidCQLQuery(BUDGET_ENDPOINT + "?query=invalid-query");
+    deleteTenant(BUDGET_TENANT_HEADER);
+  }
+}

--- a/src/test/java/org/folio/rest/impl/StorageTestSuite.java
+++ b/src/test/java/org/folio/rest/impl/StorageTestSuite.java
@@ -35,7 +35,8 @@ import static org.folio.rest.utils.TenantApiTestUtil.prepareTenant;
   EntitiesCrudTest.class,
   TenantSampleDataTest.class,
   FundsTest.class,
-  FundCodeUniquenessTest.class
+  FundCodeUniquenessTest.class,
+  BudgetTest.class
 })
 
 public class StorageTestSuite {

--- a/src/test/java/org/folio/rest/impl/TestBase.java
+++ b/src/test/java/org/folio/rest/impl/TestBase.java
@@ -35,7 +35,7 @@ import static org.junit.Assert.assertEquals;
 public abstract class TestBase {
   protected final Logger logger = LoggerFactory.getLogger(this.getClass());
 
-  private static final String TENANT_NAME = "diku";
+  static final String TENANT_NAME = "diku";
   static final String NON_EXISTED_ID = "bad500aa-aaaa-500a-aaaa-aaaaaaaaaaaa";
   static final Header TENANT_HEADER = new Header(OKAPI_HEADER_TENANT, TENANT_NAME);
 


### PR DESCRIPTION
## Purpose
https://issues.folio.org/browse/MODFISTO-31

## Approach
* Added support for querying Budget API by fund/ledger/fiscalYear fields
* Sample data adjustments

## Pre-Merge Checklist
Before merging this PR, please go through the following list and take appropriate actions.

- Does this PR meet or exceed the expected quality standards?
  - [ ] Code coverage on new code is 80% or greater
  - [ ] Duplications on new code is 3% or less
  - [ ] There are no major code smells or security issues
- Does this introduce breaking changes?
  - [ ] Were any API paths or methods changed, added or removed?
  - [ ] Were there any schema changes?
  - [ ] Did any of the interface versions change?
  - [ ] Were permissions changed, added, or removed?
  - [ ] Are there new interface dependencies?
  - [ ] There are no breaking changes in this PR.
  
If there are breaking changes, please **STOP** and consider the following:

- What other modules will these changes impact?
- Do JIRAs exist to update the impacted modules?
  - [ ] If not, please create them
  - [ ] Do they contain the appropriate level of detail?  Which endpoints/schemas changed, etc.
  - [ ] Do they have all they appropriate links to blocked/related issues?
- Are the JIRAs under active development?  
  - [ ] If not, contact the project's PO and make sure they're aware of the urgency.
- Do PRs exist for these changes?
  - [ ] If so, have they been approved?

Ideally all of the PRs involved in breaking changes would be merged in the same day to avoid breaking the folio-testing environment.  Communication is paramount if that is to be achieved, especially as the number of intermodule and inter-team dependencies increase.  

While it's helpful for reviewers to help identify potential problems, ensuring that it's safe to merge is ultimately the responsibility of the PR assignee.
