### PR TITLE
MODFISTO-37 Update LedgerFY table

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -60,10 +60,14 @@
       <artifactId>domain-models-runtime</artifactId>
       <version>${raml-module-builder.version}</version>
     </dependency>
-    <!-- The RMB runtime defines usage of log4j2 for vert.x logging interface. Including Log4j 2 SLF4J Binding to allow SLF4J API to use Log4j 2 as the implementation. -->
+    <!-- The RMB runtime defines usage of log4j2 for vert.x logging interface. Including SLF4J Bridge/JUL Adapter. -->
     <dependency>
       <groupId>org.apache.logging.log4j</groupId>
       <artifactId>log4j-slf4j-impl</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.logging.log4j</groupId>
+      <artifactId>log4j-jul</artifactId>
     </dependency>
     <!-- test dependencies -->
     <dependency>
@@ -360,7 +364,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-shade-plugin</artifactId>
-        <version>2.3</version>
+        <version>3.2.1</version>
         <executions>
           <execution>
             <phase>package</phase>

--- a/ramls/finance-storage.raml
+++ b/ramls/finance-storage.raml
@@ -21,8 +21,7 @@ resourceTypes:
   collection-get: !include raml-util/rtypes/collection-get.raml
 
 
-/finance-storage:
- /ledger-fiscal-years:
+/finance-storage/ledger-fiscal-years:
    get:
       displayName: ledger FiscalYear
       description: Get the ledger for a given fiscal year

--- a/src/main/java/org/folio/rest/impl/FinanceStorageAPI.java
+++ b/src/main/java/org/folio/rest/impl/FinanceStorageAPI.java
@@ -1,17 +1,26 @@
 package org.folio.rest.impl;
 
+import static io.vertx.core.Future.succeededFuture;
+
 import io.vertx.core.AsyncResult;
 import io.vertx.core.Context;
+import io.vertx.core.Future;
 import io.vertx.core.Handler;
+
+import java.util.List;
 import java.util.Map;
 import javax.ws.rs.core.Response;
+
 import org.folio.rest.jaxrs.model.LedgerFY;
 import org.folio.rest.jaxrs.model.LedgerFYCollection;
-import org.folio.rest.jaxrs.resource.FinanceStorage;
+import org.folio.rest.jaxrs.resource.FinanceStorageLedgerFiscalYears;
+import org.folio.rest.persist.Criteria.Criterion;
+import org.folio.rest.persist.HelperUtils;
 import org.folio.rest.persist.PgUtil;
+import org.folio.rest.persist.Tx;
 
-public class FinanceStorageAPI implements FinanceStorage {
-  private static final String LEDGERFY_TABLE = "ledgerFY";
+public class FinanceStorageAPI implements FinanceStorageLedgerFiscalYears {
+  static final String LEDGERFY_TABLE = "ledgerFY";
 
   @Override
   public void getFinanceStorageLedgerFiscalYears(int offset, int limit, String query, String lang, Map<String, String> okapiHeaders,
@@ -19,5 +28,28 @@ public class FinanceStorageAPI implements FinanceStorage {
     PgUtil.get(LEDGERFY_TABLE, LedgerFY.class, LedgerFYCollection.class, query, offset, limit, okapiHeaders, vertxContext,
         GetFinanceStorageLedgerFiscalYearsResponse.class, asyncResultHandler);
 
+  }
+
+  <T> Future<Void> saveLedgerFiscalYearRecords(Tx<T> tx, List<LedgerFY> ledgerFYs) {
+    if (ledgerFYs.isEmpty()) {
+      return succeededFuture();
+    }
+    Future<Void> future = Future.future();
+    tx.getPgClient().saveBatch(tx.getConnection(), LEDGERFY_TABLE, ledgerFYs, reply -> handleAsyncResult(future, reply));
+    return future;
+  }
+
+  <T> Future<Void> deleteLedgerFiscalYearRecords(Tx<T> tx, Criterion criterion) {
+    Future<Void> future = Future.future();
+    tx.getPgClient().delete(tx.getConnection(), LEDGERFY_TABLE, criterion, reply -> handleAsyncResult(future, reply));
+    return future;
+  }
+
+  private <T> void handleAsyncResult(Future<Void> future, AsyncResult<T> reply) {
+    if(reply.failed()) {
+      HelperUtils.handleFailure(future, reply);
+    } else {
+      future.complete();
+    }
   }
 }

--- a/src/main/java/org/folio/rest/impl/FiscalYearAPI.java
+++ b/src/main/java/org/folio/rest/impl/FiscalYearAPI.java
@@ -120,7 +120,7 @@ public class FiscalYearAPI implements FinanceStorageFiscalYears {
     log.debug("Creating new fiscal year record with id={}", fiscalYear.getId());
 
     pgClient.save(tx.getConnection(), FISCAL_YEAR_TABLE, fiscalYear.getId(), fiscalYear, reply -> {
-      if(reply.failed()) {
+      if (reply.failed()) {
         HelperUtils.handleFailure(future, reply);
       } else {
         log.info("New fiscal year record with id={} has been successfully created", fiscalYear.getId());
@@ -164,13 +164,13 @@ public class FiscalYearAPI implements FinanceStorageFiscalYears {
 
   private Future<List<Ledger>> getLedgers(Tx<FiscalYear> tx) {
     Future<List<Ledger>> future = Future.future();
-    tx.getPgClient().get(tx.getConnection(), LedgerAPI.LEDGER_TABLE, Ledger.class, new Criterion(), true, true, reply -> {
-      if(reply.failed()) {
+    pgClient.get(tx.getConnection(), LedgerAPI.LEDGER_TABLE, Ledger.class, new Criterion(), true, true, reply -> {
+      if (reply.failed()) {
         log.error("Failed to find ledgers");
         HelperUtils.handleFailure(future, reply);
       } else {
         List<Ledger> results = Optional.ofNullable(reply.result().getResults()).orElse(Collections.emptyList());
-        log.info("{} ledgers found have been found", results.size());
+        log.info("{} ledgers have been found", results.size());
         future.complete(results);
       }
     });

--- a/src/main/java/org/folio/rest/impl/FiscalYearAPI.java
+++ b/src/main/java/org/folio/rest/impl/FiscalYearAPI.java
@@ -1,21 +1,46 @@
 package org.folio.rest.impl;
 
+import java.time.Instant;
+import java.util.Collections;
+import java.util.List;
 import java.util.Map;
+import java.util.Optional;
+import java.util.UUID;
+import java.util.stream.Collectors;
 
 import javax.ws.rs.core.Response;
 
+import org.apache.commons.lang.StringUtils;
 import org.folio.rest.annotations.Validate;
 import org.folio.rest.jaxrs.model.FiscalYear;
 import org.folio.rest.jaxrs.model.FiscalYearCollection;
+import org.folio.rest.jaxrs.model.Ledger;
+import org.folio.rest.jaxrs.model.LedgerFY;
 import org.folio.rest.jaxrs.resource.FinanceStorageFiscalYears;
+import org.folio.rest.persist.HelperUtils;
 import org.folio.rest.persist.PgUtil;
+import org.folio.rest.persist.PostgresClient;
+import org.folio.rest.persist.Tx;
+import org.folio.rest.persist.Criteria.Criterion;
 
 import io.vertx.core.AsyncResult;
 import io.vertx.core.Context;
+import io.vertx.core.Future;
 import io.vertx.core.Handler;
+import io.vertx.core.Vertx;
+import io.vertx.core.logging.Logger;
+import io.vertx.core.logging.LoggerFactory;
+import io.vertx.ext.web.handler.impl.HttpStatusException;
 
 public class FiscalYearAPI implements FinanceStorageFiscalYears {
-  private static final String FISCAL_YEAR_TABLE = "fiscal_year";
+  static final String FISCAL_YEAR_TABLE = "fiscal_year";
+
+  private static final Logger log = LoggerFactory.getLogger(FiscalYearAPI.class);
+  private PostgresClient pgClient;
+
+  public FiscalYearAPI(Vertx vertx, String tenantId) {
+    pgClient = PostgresClient.getInstance(vertx, tenantId);
+  }
 
   @Override
   @Validate
@@ -28,7 +53,25 @@ public class FiscalYearAPI implements FinanceStorageFiscalYears {
   @Override
   @Validate
   public void postFinanceStorageFiscalYears(String lang, FiscalYear entity, Map<String, String> okapiHeaders, Handler<AsyncResult<Response>> asyncResultHandler, Context vertxContext) {
-    PgUtil.post(FISCAL_YEAR_TABLE, entity, okapiHeaders, vertxContext, PostFinanceStorageFiscalYearsResponse.class, asyncResultHandler);
+    Tx<FiscalYear> tx = new Tx<>(entity, pgClient);
+    HelperUtils.startTx(tx)
+      .compose(this::saveFiscalYear)
+      .compose(this::createLedgerFiscalYearRecords)
+      .compose(HelperUtils::endTx)
+      .setHandler(result -> {
+        if (result.failed()) {
+          HttpStatusException cause = (HttpStatusException) result.cause();
+          log.error("New fiscal year record creation has failed: {}", cause, tx.getEntity());
+
+          // The result of rollback operation is not so important, main failure cause is used to build the response
+          HelperUtils.rollbackTransaction(tx).setHandler(res -> HelperUtils.replyWithErrorResponse(asyncResultHandler, cause));
+        } else {
+          log.info("New fiscal year record {} and associated data were successfully created", tx.getEntity());
+          asyncResultHandler.handle(Future.succeededFuture(PostFinanceStorageFiscalYearsResponse
+            .respond201WithApplicationJson(result.result().getEntity(), PostFinanceStorageFiscalYearsResponse.headersFor201()
+              .withLocation(HelperUtils.getEndpoint(FinanceStorageFiscalYears.class) + result.result().getEntity().getId()))));
+        }
+      });
   }
 
   @Override
@@ -40,12 +83,97 @@ public class FiscalYearAPI implements FinanceStorageFiscalYears {
   @Override
   @Validate
   public void deleteFinanceStorageFiscalYearsById(String id, String lang, Map<String, String> okapiHeaders, Handler<AsyncResult<Response>> asyncResultHandler, Context vertxContext) {
-    PgUtil.deleteById(FISCAL_YEAR_TABLE, id, okapiHeaders, vertxContext, DeleteFinanceStorageFiscalYearsByIdResponse.class, asyncResultHandler);
+    Tx<String> tx = new Tx<>(id, pgClient);
+    HelperUtils.startTx(tx)
+      .compose(ok -> new FinanceStorageAPI().deleteLedgerFiscalYearRecords(tx,
+          HelperUtils.getCriterionByFieldNameAndValue("fiscalYearId", "=", id)))
+      .compose(ok -> HelperUtils.deleteRecordById(tx, FISCAL_YEAR_TABLE))
+      .compose(HelperUtils::endTx)
+      .setHandler(result -> {
+        if (result.failed()) {
+          HttpStatusException cause = (HttpStatusException) result.cause();
+          log.error("Deletion of the fiscal year record {} has failed", cause, tx.getEntity());
+
+          // The result of rollback operation is not so important, main failure cause is used to build the response
+          HelperUtils.rollbackTransaction(tx).setHandler(res -> HelperUtils.replyWithErrorResponse(asyncResultHandler, cause));
+        } else {
+          log.info("Fiscal year record {} and associated data were successfully deleted", tx.getEntity());
+          asyncResultHandler.handle(Future.succeededFuture(DeleteFinanceStorageFiscalYearsByIdResponse.respond204()));
+        }
+      });
   }
 
   @Override
   @Validate
   public void putFinanceStorageFiscalYearsById(String id, String lang, FiscalYear entity, Map<String, String> okapiHeaders, Handler<AsyncResult<Response>> asyncResultHandler, Context vertxContext) {
     PgUtil.put(FISCAL_YEAR_TABLE, entity, id, okapiHeaders, vertxContext, PutFinanceStorageFiscalYearsByIdResponse.class, asyncResultHandler);
+  }
+
+  private Future<Tx<FiscalYear>> saveFiscalYear(Tx<FiscalYear> tx) {
+    Future<Tx<FiscalYear>> future = Future.future();
+
+    FiscalYear fiscalYear = tx.getEntity();
+    if (fiscalYear.getId() == null) {
+      fiscalYear.setId(UUID.randomUUID().toString());
+    }
+
+    log.debug("Creating new fiscal year record with id={}", fiscalYear.getId());
+
+    pgClient.save(tx.getConnection(), FISCAL_YEAR_TABLE, fiscalYear.getId(), fiscalYear, reply -> {
+      if(reply.failed()) {
+        HelperUtils.handleFailure(future, reply);
+      } else {
+        log.info("New fiscal year record with id={} has been successfully created", fiscalYear.getId());
+        future.complete(tx);
+      }
+    });
+    return future;
+  }
+
+  private Future<Tx<FiscalYear>> createLedgerFiscalYearRecords(Tx<FiscalYear> tx) {
+    FiscalYear fiscalYear = tx.getEntity();
+
+    // In case no currency or period's end date of the fiscal year is for some reason in past, do not create any related records
+    if (StringUtils.isEmpty(fiscalYear.getCurrency()) || fiscalYear.getPeriodEnd().toInstant().isBefore(Instant.now())) {
+      return Future.succeededFuture(tx);
+    }
+
+    Future<Tx<FiscalYear>> future = Future.future();
+    getLedgers(tx)
+      .map(ledgers -> buildLedgerFiscalYearRecords(fiscalYear, ledgers))
+      .compose(ledgerFYs -> new FinanceStorageAPI().saveLedgerFiscalYearRecords(tx, ledgerFYs))
+      .setHandler(result -> {
+        if (result.failed()) {
+          HelperUtils.handleFailure(future, result);
+        } else {
+          future.complete(tx);
+        }
+      });
+    return future;
+  }
+
+  private List<LedgerFY> buildLedgerFiscalYearRecords(FiscalYear fiscalYear, List<Ledger> ledgers) {
+    return ledgers.stream()
+      .map(ledger -> new LedgerFY()
+        // No need to generate uuids here because PostgresClient.saveBatch(...) generates ids for each record
+        .withCurrency(fiscalYear.getCurrency())
+        .withLedgerId(ledger.getId())
+        .withFiscalYearId(fiscalYear.getId()))
+      .collect(Collectors.toList());
+  }
+
+  private Future<List<Ledger>> getLedgers(Tx<FiscalYear> tx) {
+    Future<List<Ledger>> future = Future.future();
+    tx.getPgClient().get(tx.getConnection(), LedgerAPI.LEDGER_TABLE, Ledger.class, new Criterion(), true, true, reply -> {
+      if(reply.failed()) {
+        log.error("Failed to find ledgers");
+        HelperUtils.handleFailure(future, reply);
+      } else {
+        List<Ledger> results = Optional.ofNullable(reply.result().getResults()).orElse(Collections.emptyList());
+        log.info("{} ledgers found have been found", results.size());
+        future.complete(results);
+      }
+    });
+    return future;
   }
 }

--- a/src/main/java/org/folio/rest/impl/LedgerAPI.java
+++ b/src/main/java/org/folio/rest/impl/LedgerAPI.java
@@ -2,17 +2,45 @@ package org.folio.rest.impl;
 
 import io.vertx.core.AsyncResult;
 import io.vertx.core.Context;
+import io.vertx.core.Future;
 import io.vertx.core.Handler;
+import io.vertx.core.Vertx;
+import io.vertx.core.logging.Logger;
+import io.vertx.core.logging.LoggerFactory;
+import io.vertx.ext.web.handler.impl.HttpStatusException;
+
+import java.time.Instant;
+import java.util.Collections;
+import java.util.List;
 import java.util.Map;
+import java.util.Optional;
+import java.util.UUID;
+import java.util.stream.Collectors;
+
 import javax.ws.rs.core.Response;
+
+import org.apache.commons.lang3.StringUtils;
 import org.folio.rest.annotations.Validate;
+import org.folio.rest.jaxrs.model.FiscalYear;
 import org.folio.rest.jaxrs.model.Ledger;
 import org.folio.rest.jaxrs.model.LedgerCollection;
+import org.folio.rest.jaxrs.model.LedgerFY;
 import org.folio.rest.jaxrs.resource.FinanceStorageLedgers;
+import org.folio.rest.persist.Criteria.Criterion;
+import org.folio.rest.persist.HelperUtils;
 import org.folio.rest.persist.PgUtil;
+import org.folio.rest.persist.PostgresClient;
+import org.folio.rest.persist.Tx;
 
 public class LedgerAPI implements FinanceStorageLedgers {
-  private static final String LEDGER_TABLE = "ledger";
+  static final String LEDGER_TABLE = "ledger";
+
+  private static final Logger log = LoggerFactory.getLogger(LedgerAPI.class);
+  private PostgresClient pgClient;
+
+  public LedgerAPI(Vertx vertx, String tenantId) {
+    pgClient = PostgresClient.getInstance(vertx, tenantId);
+  }
 
   @Override
   @Validate
@@ -24,7 +52,25 @@ public class LedgerAPI implements FinanceStorageLedgers {
   @Override
   @Validate
   public void postFinanceStorageLedgers(String lang, Ledger entity, Map<String, String> okapiHeaders, Handler<AsyncResult<Response>> asyncResultHandler, Context vertxContext) {
-    PgUtil.post(LEDGER_TABLE, entity, okapiHeaders, vertxContext, PostFinanceStorageLedgersResponse.class, asyncResultHandler);
+    Tx<Ledger> tx = new Tx<>(entity, pgClient);
+    HelperUtils.startTx(tx)
+      .compose(this::saveLedger)
+      .compose(this::createLedgerFiscalYearRecords)
+      .compose(HelperUtils::endTx)
+      .setHandler(result -> {
+        if (result.failed()) {
+          HttpStatusException cause = (HttpStatusException) result.cause();
+          log.error("New ledger record creation has failed: {}", cause, tx.getEntity());
+
+          // The result of rollback operation is not so important, main failure cause is used to build the response
+          HelperUtils.rollbackTransaction(tx).setHandler(res -> HelperUtils.replyWithErrorResponse(asyncResultHandler, cause));
+        } else {
+          log.info("New ledger record {} and associated data were successfully created", tx.getEntity());
+          asyncResultHandler.handle(Future.succeededFuture(PostFinanceStorageLedgersResponse
+            .respond201WithApplicationJson(result.result().getEntity(), PostFinanceStorageLedgersResponse.headersFor201()
+              .withLocation(HelperUtils.getEndpoint(FinanceStorageLedgers.class) + result.result().getEntity().getId()))));
+        }
+      });
   }
 
   @Override
@@ -36,7 +82,24 @@ public class LedgerAPI implements FinanceStorageLedgers {
   @Override
   @Validate
   public void deleteFinanceStorageLedgersById(String id, String lang, Map<String, String> okapiHeaders, Handler<AsyncResult<Response>> asyncResultHandler, Context vertxContext) {
-    PgUtil.deleteById(LEDGER_TABLE, id, okapiHeaders, vertxContext, DeleteFinanceStorageLedgersByIdResponse.class, asyncResultHandler);
+    Tx<String> tx = new Tx<>(id, pgClient);
+    HelperUtils.startTx(tx)
+      .compose(ok -> new FinanceStorageAPI().deleteLedgerFiscalYearRecords(tx,
+        HelperUtils.getCriterionByFieldNameAndValue("ledgerId", "=", id)))
+      .compose(ok -> HelperUtils.deleteRecordById(tx, LEDGER_TABLE))
+      .compose(HelperUtils::endTx)
+      .setHandler(result -> {
+        if (result.failed()) {
+          HttpStatusException cause = (HttpStatusException) result.cause();
+          log.error("Deletion of the ledger record {} has failed", cause, tx.getEntity());
+
+          // The result of rollback operation is not so important, main failure cause is used to build the response
+          HelperUtils.rollbackTransaction(tx).setHandler(res -> HelperUtils.replyWithErrorResponse(asyncResultHandler, cause));
+        } else {
+          log.info("Ledger record {} and associated data were successfully deleted", tx.getEntity());
+          asyncResultHandler.handle(Future.succeededFuture(DeleteFinanceStorageLedgersByIdResponse.respond204()));
+        }
+      });
   }
 
   @Override
@@ -45,4 +108,66 @@ public class LedgerAPI implements FinanceStorageLedgers {
     PgUtil.put(LEDGER_TABLE, entity, id, okapiHeaders, vertxContext, PutFinanceStorageLedgersByIdResponse.class, asyncResultHandler);
   }
 
+  private Future<Tx<Ledger>> saveLedger(Tx<Ledger> tx) {
+    Future<Tx<Ledger>> future = Future.future();
+
+    Ledger ledger = tx.getEntity();
+    if (ledger.getId() == null) {
+      ledger.setId(UUID.randomUUID().toString());
+    }
+
+    log.debug("Creating new ledger record with id={}", ledger.getId());
+
+    pgClient.save(tx.getConnection(), LEDGER_TABLE, ledger.getId(), ledger, reply -> {
+      if(reply.failed()) {
+        HelperUtils.handleFailure(future, reply);
+      } else {
+        log.info("New ledger record with id={} has been successfully created", ledger.getId());
+        future.complete(tx);
+      }
+    });
+    return future;
+  }
+
+  private Future<Tx<Ledger>> createLedgerFiscalYearRecords(Tx<Ledger> tx) {
+    Future<Tx<Ledger>> future = Future.future();
+    getFiscalYears(tx)
+      .map(fiscalYears -> buildLedgerFiscalYearRecords(tx.getEntity(), fiscalYears))
+      .compose(ledgerFYs -> new FinanceStorageAPI().saveLedgerFiscalYearRecords(tx, ledgerFYs))
+      .setHandler(result -> {
+        if (result.failed()) {
+          HelperUtils.handleFailure(future, result);
+        } else {
+          future.complete(tx);
+        }
+      });
+    return future;
+  }
+
+  private List<LedgerFY> buildLedgerFiscalYearRecords(Ledger ledger, List<FiscalYear> fiscalYears) {
+    return fiscalYears.stream()
+      .filter(fy -> StringUtils.isNotEmpty(fy.getCurrency()))
+      .map(fiscalYear -> new LedgerFY()
+        // No need to generate uuids here because PostgresClient.saveBatch(...) generates ids for each record
+        .withCurrency(fiscalYear.getCurrency())
+        .withLedgerId(ledger.getId())
+        .withFiscalYearId(fiscalYear.getId()))
+      .collect(Collectors.toList());
+  }
+
+  private Future<List<FiscalYear>> getFiscalYears(Tx<Ledger> tx) {
+    Future<List<FiscalYear>> future = Future.future();
+    Criterion criterion = HelperUtils.getCriterionByFieldNameAndValue("periodEnd", ">", Instant.now().toString());
+    tx.getPgClient().get(tx.getConnection(), FiscalYearAPI.FISCAL_YEAR_TABLE, FiscalYear.class, criterion, true, true, reply -> {
+      if(reply.failed()) {
+        log.error("Failed to find fiscal years");
+        HelperUtils.handleFailure(future, reply);
+      } else {
+        List<FiscalYear> results = Optional.ofNullable(reply.result().getResults()).orElse(Collections.emptyList());
+        log.info("{} fiscal years have been found", results.size());
+        future.complete(results);
+      }
+    });
+    return future;
+  }
 }

--- a/src/main/java/org/folio/rest/impl/LedgerAPI.java
+++ b/src/main/java/org/folio/rest/impl/LedgerAPI.java
@@ -119,7 +119,7 @@ public class LedgerAPI implements FinanceStorageLedgers {
     log.debug("Creating new ledger record with id={}", ledger.getId());
 
     pgClient.save(tx.getConnection(), LEDGER_TABLE, ledger.getId(), ledger, reply -> {
-      if(reply.failed()) {
+      if (reply.failed()) {
         HelperUtils.handleFailure(future, reply);
       } else {
         log.info("New ledger record with id={} has been successfully created", ledger.getId());
@@ -158,8 +158,8 @@ public class LedgerAPI implements FinanceStorageLedgers {
   private Future<List<FiscalYear>> getFiscalYears(Tx<Ledger> tx) {
     Future<List<FiscalYear>> future = Future.future();
     Criterion criterion = HelperUtils.getCriterionByFieldNameAndValue("periodEnd", ">", Instant.now().toString());
-    tx.getPgClient().get(tx.getConnection(), FiscalYearAPI.FISCAL_YEAR_TABLE, FiscalYear.class, criterion, true, true, reply -> {
-      if(reply.failed()) {
+    pgClient.get(tx.getConnection(), FiscalYearAPI.FISCAL_YEAR_TABLE, FiscalYear.class, criterion, true, true, reply -> {
+      if (reply.failed()) {
         log.error("Failed to find fiscal years");
         HelperUtils.handleFailure(future, reply);
       } else {

--- a/src/main/java/org/folio/rest/impl/TenantReferenceAPI.java
+++ b/src/main/java/org/folio/rest/impl/TenantReferenceAPI.java
@@ -19,11 +19,11 @@ import org.folio.rest.jaxrs.resource.FinanceStorageGroupFundFiscalYears;
 import org.folio.rest.jaxrs.resource.FinanceStorageLedgers;
 import org.folio.rest.jaxrs.resource.FinanceStorageGroups;
 import org.folio.rest.jaxrs.resource.FinanceStorageTransactions;
+import org.folio.rest.persist.HelperUtils;
 import org.folio.rest.persist.PostgresClient;
 import org.folio.rest.tools.utils.TenantLoading;
 import org.folio.rest.tools.utils.TenantTool;
 
-import javax.ws.rs.Path;
 import javax.ws.rs.core.Response;
 import java.util.List;
 import java.util.Map;
@@ -139,6 +139,6 @@ public class TenantReferenceAPI extends TenantAPI {
   }
 
   private static String getUriPath(Class<?> clazz) {
-    return clazz.getAnnotation(Path.class).value().replaceFirst("/", "");
+    return HelperUtils.getEndpoint(clazz).replaceFirst("/", "");
   }
 }

--- a/src/main/java/org/folio/rest/persist/HelperUtils.java
+++ b/src/main/java/org/folio/rest/persist/HelperUtils.java
@@ -1,0 +1,92 @@
+package org.folio.rest.persist;
+
+import static io.vertx.core.Future.succeededFuture;
+import static javax.ws.rs.core.HttpHeaders.CONTENT_TYPE;
+
+import java.util.Optional;
+
+import javax.ws.rs.Path;
+import javax.ws.rs.core.MediaType;
+import javax.ws.rs.core.Response;
+
+import org.folio.rest.persist.Criteria.Criteria;
+import org.folio.rest.persist.Criteria.Criterion;
+
+import io.vertx.core.AsyncResult;
+import io.vertx.core.Future;
+import io.vertx.core.Handler;
+import io.vertx.ext.web.handler.impl.HttpStatusException;
+
+public final class HelperUtils {
+  private HelperUtils() { }
+
+  public static String getEndpoint(Class<?> clazz) {
+    return clazz.getAnnotation(Path.class).value();
+  }
+
+  public static <T> Future<Tx<T>> startTx(Tx<T> tx) {
+    Future<Tx<T>> future = Future.future();
+
+    tx.getPgClient().startTx(sqlConnection -> {
+      tx.setConnection(sqlConnection);
+      future.complete(tx);
+    });
+    return future;
+  }
+
+  public static <T> Future<Tx<T>> endTx(Tx<T> tx) {
+    Future<Tx<T>> future = Future.future();
+    tx.getPgClient().endTx(tx.getConnection(), v -> future.complete(tx));
+    return future;
+  }
+
+  public static Future<Tx<String>> deleteRecordById(Tx<String> tx, String table) {
+    Future<Tx<String>> future = Future.future();
+
+    tx.getPgClient().delete(tx.getConnection(), table, tx.getEntity(), reply -> {
+      if(reply.failed()) {
+        HelperUtils.handleFailure(future, reply);
+      } else if (reply.result().getUpdated() == 0) {
+        future.fail(new HttpStatusException(Response.Status.NOT_FOUND.getStatusCode()));
+      } else {
+        future.complete(tx);
+      }
+    });
+    return future;
+  }
+
+  public static void handleFailure(Future future, AsyncResult reply) {
+    Throwable cause = reply.cause();
+    String badRequestMessage = PgExceptionUtil.badRequestMessage(cause);
+    if (badRequestMessage != null) {
+      future.fail(new HttpStatusException(Response.Status.BAD_REQUEST.getStatusCode(), badRequestMessage));
+    } else {
+      future.fail(new HttpStatusException(Response.Status.INTERNAL_SERVER_ERROR.getStatusCode(), cause.getMessage()));
+    }
+  }
+
+  public static Future<Void> rollbackTransaction(Tx<?> tx) {
+    Future<Void> future = Future.future();
+    if (tx.getConnection().failed()) {
+      future.fail(tx.getConnection().cause());
+    } else {
+      tx.getPgClient().rollbackTx(tx.getConnection(), future);
+    }
+    return future;
+  }
+
+  public static void replyWithErrorResponse(Handler<AsyncResult<Response>> asyncResultHandler, HttpStatusException cause) {
+    asyncResultHandler.handle(succeededFuture(Response.status(cause.getStatusCode())
+      .entity(Optional.of(cause).map(HttpStatusException::getPayload).orElse(cause.getMessage()))
+      .header(CONTENT_TYPE, MediaType.TEXT_PLAIN)
+      .build()));
+  }
+
+  public static Criterion getCriterionByFieldNameAndValue(String filedName, String operation, String fieldValue) {
+    Criteria a = new Criteria();
+    a.addField("'" + filedName + "'");
+    a.setOperation(operation);
+    a.setVal(fieldValue);
+    return new Criterion(a);
+  }
+}

--- a/src/main/java/org/folio/rest/persist/Tx.java
+++ b/src/main/java/org/folio/rest/persist/Tx.java
@@ -1,0 +1,32 @@
+package org.folio.rest.persist;
+
+import io.vertx.core.AsyncResult;
+import io.vertx.ext.sql.SQLConnection;
+
+public class Tx<T> {
+
+  private T entity;
+  private PostgresClient pgClient;
+  private AsyncResult<SQLConnection> sqlConnection;
+
+  public Tx(T entity, PostgresClient pgClient) {
+    this.entity = entity;
+    this.pgClient = pgClient;
+  }
+
+  public T getEntity() {
+    return entity;
+  }
+
+  public PostgresClient getPgClient() {
+    return pgClient;
+  }
+
+  public AsyncResult<SQLConnection> getConnection() {
+    return sqlConnection;
+  }
+
+  public void setConnection(AsyncResult<SQLConnection> sqlConnection) {
+    this.sqlConnection = sqlConnection;
+  }
+}

--- a/src/main/resources/templates/db_scripts/schema.json
+++ b/src/main/resources/templates/db_scripts/schema.json
@@ -100,6 +100,12 @@
       "tableName": "fiscal_year",
       "fromModuleVersion": 1.0,
       "withMetadata": true,
+      "index": [
+        {
+          "fieldName" : "periodEnd",
+          "tOps": "ADD"
+        }
+      ],
       "ginIndex": [
         {
           "fieldName": "name",
@@ -287,6 +293,12 @@
           "targetTable": "fiscal_year",
           "tableAlias": "ledgerFY",
           "targetTableAlias": "fiscalYear"
+        }
+      ],
+      "uniqueIndex": [
+        {
+          "fieldName": "ledgerId, fiscalYearId",
+          "tOps": "ADD"
         }
       ]
     },

--- a/src/test/java/org/folio/rest/impl/TestBase.java
+++ b/src/test/java/org/folio/rest/impl/TestBase.java
@@ -3,6 +3,7 @@ package org.folio.rest.impl;
 import io.restassured.http.ContentType;
 import io.restassured.http.Header;
 import io.restassured.response.Response;
+import io.restassured.response.ValidatableResponse;
 import io.vertx.core.Vertx;
 import io.vertx.core.json.JsonObject;
 import io.vertx.core.logging.Logger;
@@ -64,16 +65,16 @@ public abstract class TestBase {
     }
   }
 
-  void verifyCollectionQuantity(String endpoint, int quantity, Header tenantHeader) throws MalformedURLException {
-    getData(endpoint, tenantHeader)
+  ValidatableResponse verifyCollectionQuantity(String endpoint, int quantity, Header tenantHeader) throws MalformedURLException {
+    return getData(endpoint, tenantHeader)
       .then()
         .log().all()
         .statusCode(200)
         .body("totalRecords", equalTo(quantity));
   }
 
-  void verifyCollectionQuantity(String endpoint, int quantity) throws MalformedURLException {
-    verifyCollectionQuantity(endpoint, quantity, TENANT_HEADER);
+  ValidatableResponse verifyCollectionQuantity(String endpoint, int quantity) throws MalformedURLException {
+    return verifyCollectionQuantity(endpoint, quantity, TENANT_HEADER);
   }
 
   Response getData(String endpoint, Header tenantHeader) throws MalformedURLException {
@@ -150,8 +151,8 @@ public abstract class TestBase {
       .delete(storageUrl(endpoint));
   }
 
-  String createEntity(String endpoint, String entity) throws MalformedURLException {
-    return postData(endpoint, entity)
+  String createEntity(String endpoint, Object entity) throws MalformedURLException {
+    return postData(endpoint, JsonObject.mapFrom(entity).encode())
       .then().log().all()
       .statusCode(201)
       .extract()

--- a/src/test/java/org/folio/rest/utils/TestEntities.java
+++ b/src/test/java/org/folio/rest/utils/TestEntities.java
@@ -1,7 +1,5 @@
 package org.folio.rest.utils;
 
-import javax.ws.rs.Path;
-
 import org.folio.rest.jaxrs.model.Budget;
 import org.folio.rest.jaxrs.model.FiscalYear;
 import org.folio.rest.jaxrs.model.Fund;
@@ -20,18 +18,19 @@ import org.folio.rest.jaxrs.resource.FinanceStorageGroupFundFiscalYears;
 import org.folio.rest.jaxrs.resource.FinanceStorageGroups;
 import org.folio.rest.jaxrs.resource.FinanceStorageLedgers;
 import org.folio.rest.jaxrs.resource.FinanceStorageTransactions;
+import org.folio.rest.persist.HelperUtils;
 
 public enum TestEntities {
   //The Order is important because of the foreign key relationships
-  FISCAL_YEAR(getEndpoint(FinanceStorageFiscalYears.class), FiscalYear.class, "data/fiscal-years/", "fy19.json", "name", "FY19", 2),
-  LEDGER(getEndpoint(FinanceStorageLedgers.class), Ledger.class, "data/ledgers/", "One-time.json", "code", "One-time", 3),
-  FUND_TYPE(getEndpoint(FinanceStorageFundTypes.class), FundType.class, "data/fund-types/", "approvals.json", "name", "New type name", 26),
-  FUND(getEndpoint(FinanceStorageFunds.class), Fund.class, "data/funds/", "AFRICAHIST.json", "name", "African History", 21),
-  BUDGET(getEndpoint(FinanceStorageBudgets.class), Budget.class, "data/budgets/", "AFRICAHIST-FY19.json", "name", "AFRICAHIST-FY19", 21),
-  TRANSACTION(getEndpoint(FinanceStorageTransactions.class), Transaction.class, "data/transactions/", "payment.json", "source", "Voucher", 5),
-  FUND_DISTRIBUTION(getEndpoint(FinanceStorageFundDistributions.class), FundDistribution.class, "", "fund_distribution.sample", "currency", "CAD", 0),
-  GROUP(getEndpoint(FinanceStorageGroups.class), Group.class, "data/groups/", "HIST.json", "name", "New name", 1),
-  GROUP_FUND_FY(getEndpoint(FinanceStorageGroupFundFiscalYears.class), GroupFundFiscalYear.class, "data/group-fund-fiscal-years/", "AFRICAHIST-FY19.json", "available", "1.0", 12);
+  FISCAL_YEAR(HelperUtils.getEndpoint(FinanceStorageFiscalYears.class), FiscalYear.class, "data/fiscal-years/", "fy19.json", "name", "FY19", 2),
+  LEDGER(HelperUtils.getEndpoint(FinanceStorageLedgers.class), Ledger.class, "data/ledgers/", "One-time.json", "code", "One-time", 3),
+  FUND_TYPE(HelperUtils.getEndpoint(FinanceStorageFundTypes.class), FundType.class, "data/fund-types/", "approvals.json", "name", "New type name", 26),
+  FUND(HelperUtils.getEndpoint(FinanceStorageFunds.class), Fund.class, "data/funds/", "AFRICAHIST.json", "name", "African History", 21),
+  BUDGET(HelperUtils.getEndpoint(FinanceStorageBudgets.class), Budget.class, "data/budgets/", "AFRICAHIST-FY19.json", "name", "AFRICAHIST-FY19", 21),
+  TRANSACTION(HelperUtils.getEndpoint(FinanceStorageTransactions.class), Transaction.class, "data/transactions/", "payment.json", "source", "Voucher", 5),
+  FUND_DISTRIBUTION(HelperUtils.getEndpoint(FinanceStorageFundDistributions.class), FundDistribution.class, "", "fund_distribution.sample", "currency", "CAD", 0),
+  GROUP(HelperUtils.getEndpoint(FinanceStorageGroups.class), Group.class, "data/groups/", "HIST.json", "name", "New name", 1),
+  GROUP_FUND_FY(HelperUtils.getEndpoint(FinanceStorageGroupFundFiscalYears.class), GroupFundFiscalYear.class, "data/group-fund-fiscal-years/", "AFRICAHIST-FY19.json", "available", "1.0", 12);
 
 
   TestEntities(String endpoint, Class<?> clazz, String pathToSamples, String sampleFileName, String updatedFieldName,
@@ -93,9 +92,5 @@ public enum TestEntities {
 
   public void setId(String id) {
     this.sampleId = id;
-  }
-
-  private static String getEndpoint(Class<?> clazz) {
-    return clazz.getAnnotation(Path.class).value();
   }
 }


### PR DESCRIPTION
## Purpose
[MODFISTO-37](https://issues.folio.org/browse/MODFISTO-37) Update LedgerFY table

## Approach
- creating `LedgerFY` records when new ledger or fiscal year is created
- deleting `LedgerFY` records when ledger or fiscal year is deleted (basically it is not included into story but had to be implemented to not complicate unit testing)
- generation of the `LedgerFY` records is done in java code to generate uuid for each record (generation on postgres is deprecated)
- new index for "periodEnd" is added to fiscal year table because the logic  searches for FYs by this criteria

#### TODOS and Open Questions
- [x] At the moment for fiscal years which do not have currency code, the `ledgerFY` record is not created because currency is required (but as we work inside storage, such records will not be validated upon insert into DB so they still can be created breaking contract (schema definition))

## Pre-Merge Checklist
Before merging this PR, please go through the following list and take appropriate actions.

- Does this PR meet or exceed the expected quality standards?
  - [x] Code coverage on new code is 80% or greater
  - [x] Duplications on new code is 3% or less
  - [x] There are no major code smells or security issues
- Does this introduce breaking changes?
  - [x] There are no breaking changes in this PR.
