### PR TITLE
MODFISTO-56 Support all-or-nothing operations for encumbrances by order

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -21,7 +21,7 @@
     <raml-module-builder.version>28.1.0</raml-module-builder.version>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <jmockit.version>1.48</jmockit.version>
-<!--    <argLine />-->
+    <argLine />
   </properties>
 
   <repositories>

--- a/pom.xml
+++ b/pom.xml
@@ -18,10 +18,10 @@
     <ramlfiles_path>${basedir}/ramls</ramlfiles_path>
     <ramlfiles_util_path>${ramlfiles_path}/raml-util</ramlfiles_util_path>
     <ramlfiles_acq_models_path>${ramlfiles_path}/acq-models</ramlfiles_acq_models_path>
-    <raml-module-builder.version>27.1.1</raml-module-builder.version>
+    <raml-module-builder.version>28.1.0</raml-module-builder.version>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <jmockit.version>1.48</jmockit.version>
-    <argLine />
+<!--    <argLine />-->
   </properties>
 
   <repositories>
@@ -75,7 +75,7 @@
     <dependency>
       <groupId>io.vertx</groupId>
       <artifactId>vertx-junit5</artifactId>
-      <version>3.5.4</version>
+      <version>3.8.1</version>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/ramls/transaction.raml
+++ b/ramls/transaction.raml
@@ -33,7 +33,8 @@ resourceTypes:
       exampleItem: !include acq-models/mod-finance/examples/transaction.sample
       schemaCollection: transaction-collection
       schemaItem: transaction
-  is: [validate]
+  post:
+    is: [validate]
   get:
     description: Get list of transactions
     is: [
@@ -49,4 +50,5 @@ resourceTypes:
       collection-item:
         exampleItem: !include acq-models/mod-finance/examples/transaction.sample
         schema: transaction
-    is: [validate]
+    put:
+      is: [validate]

--- a/src/main/java/org/folio/rest/impl/FundAPI.java
+++ b/src/main/java/org/folio/rest/impl/FundAPI.java
@@ -3,6 +3,7 @@ package org.folio.rest.impl;
 import static io.vertx.core.Future.succeededFuture;
 import static org.folio.rest.impl.BudgetAPI.BUDGET_TABLE;
 import static org.folio.rest.impl.FiscalYearAPI.FISCAL_YEAR_TABLE;
+import static org.folio.rest.persist.HelperUtils.getFullTableName;
 
 import java.util.Map;
 
@@ -37,12 +38,8 @@ public class FundAPI implements FinanceStorageFunds {
   private PostgresClient pgClient;
   private String tenantId;
 
-  public FundAPI(String tenantId) {
-    this.tenantId = tenantId;
-  }
-
   public FundAPI(Vertx vertx, String tenantId) {
-    this(tenantId);
+    this.tenantId = tenantId;
     pgClient = PostgresClient.getInstance(vertx, tenantId);
   }
 
@@ -149,8 +146,8 @@ public class FundAPI implements FinanceStorageFunds {
     Promise<Tx<Fund>> promise = Promise.promise();
 
     Fund fund = fundTx.getEntity();
-    String fullBudgetTableName = PostgresClient.convertToPsqlStandard(tenantId) + "." + BUDGET_TABLE;
-    String fullFYTableName = PostgresClient.convertToPsqlStandard(tenantId) + "." + FISCAL_YEAR_TABLE;
+    String fullBudgetTableName = getFullTableName(tenantId, BUDGET_TABLE);
+    String fullFYTableName = getFullTableName(tenantId, FISCAL_YEAR_TABLE);
 
     JsonArray queryParams = new JsonArray();
     queryParams.add("\"" + fund.getFundStatus() + "\"");

--- a/src/main/java/org/folio/rest/impl/LedgerAPI.java
+++ b/src/main/java/org/folio/rest/impl/LedgerAPI.java
@@ -4,6 +4,7 @@ import static io.vertx.core.Future.succeededFuture;
 import static org.folio.rest.impl.BudgetAPI.BUDGET_TABLE;
 import static org.folio.rest.impl.FiscalYearAPI.FISCAL_YEAR_TABLE;
 import static org.folio.rest.impl.FundAPI.FUND_TABLE;
+import static org.folio.rest.persist.HelperUtils.getFullTableName;
 
 import java.time.Instant;
 import java.util.Collections;
@@ -165,8 +166,8 @@ public class LedgerAPI implements FinanceStorageLedgers {
     if (CollectionUtils.isEmpty(fundIds)) {
       promise.complete(tx);
     } else {
-      String fullBudgetTableName = PostgresClient.convertToPsqlStandard(tenantId) + "." + BUDGET_TABLE;
-      String fullFYTableName = PostgresClient.convertToPsqlStandard(tenantId) + "." + FISCAL_YEAR_TABLE;
+      String fullBudgetTableName = getFullTableName(tenantId, BUDGET_TABLE);
+      String fullFYTableName = getFullTableName(tenantId, FISCAL_YEAR_TABLE);
       String queryPlaceHolders = fundIds.stream().map(s -> "?").collect(Collectors.joining(", ", "", ""));
       JsonArray params = new JsonArray();
       params.add("\"" + ledger.getLedgerStatus() + "\"");
@@ -222,7 +223,7 @@ public class LedgerAPI implements FinanceStorageLedgers {
   private Future<Tx<List<String>>> updateRelatedFunds(Tx<Ledger> tx) {
     Promise<Tx<List<String>>> promise = Promise.promise();
     Ledger ledger = tx.getEntity();
-    String fullFundTableName = PostgresClient.convertToPsqlStandard(tenantId) + "." + FUND_TABLE;
+    String fullFundTableName = getFullTableName(tenantId, FUND_TABLE);
     String sql = "UPDATE " + fullFundTableName + "  SET jsonb = jsonb_set(jsonb,'{fundStatus}', ?::jsonb) " +
       "WHERE (ledgerId = ?) AND (jsonb->>'fundStatus' <> ?) RETURNING id";
     JsonArray params = new JsonArray();

--- a/src/main/java/org/folio/rest/impl/TenantReferenceAPI.java
+++ b/src/main/java/org/folio/rest/impl/TenantReferenceAPI.java
@@ -16,6 +16,7 @@ import org.folio.rest.jaxrs.resource.FinanceStorageFunds;
 import org.folio.rest.jaxrs.resource.FinanceStorageGroupFundFiscalYears;
 import org.folio.rest.jaxrs.resource.FinanceStorageGroups;
 import org.folio.rest.jaxrs.resource.FinanceStorageLedgers;
+import org.folio.rest.jaxrs.resource.FinanceStorageOrderTransactionSummaries;
 import org.folio.rest.jaxrs.resource.FinanceStorageTransactions;
 import org.folio.rest.persist.HelperUtils;
 import org.folio.rest.persist.PostgresClient;
@@ -84,6 +85,7 @@ public class TenantReferenceAPI extends TenantAPI {
         .add("funds", getUriPath(FinanceStorageFunds.class))
         .add("budgets", getUriPath(FinanceStorageBudgets.class))
         .add("group-fund-fiscal-years", getUriPath(FinanceStorageGroupFundFiscalYears.class))
+        .add("order-transaction-summaries", getUriPath(FinanceStorageOrderTransactionSummaries.class))
         .add("transactions", getUriPath(FinanceStorageTransactions.class));
       loadData = true;
     }

--- a/src/main/java/org/folio/rest/impl/TransactionAPI.java
+++ b/src/main/java/org/folio/rest/impl/TransactionAPI.java
@@ -1,5 +1,7 @@
 package org.folio.rest.impl;
 
+import static org.folio.rest.transaction.AbstractTransactionHandler.TRANSACTION_TABLE;
+
 import java.util.Map;
 
 import javax.ws.rs.core.Response;
@@ -9,13 +11,15 @@ import org.folio.rest.jaxrs.model.Transaction;
 import org.folio.rest.jaxrs.model.TransactionCollection;
 import org.folio.rest.jaxrs.resource.FinanceStorageTransactions;
 import org.folio.rest.persist.PgUtil;
+import org.folio.rest.transaction.DefaultTransactionHandler;
+import org.folio.rest.transaction.EncumbranceHandler;
+import org.folio.rest.transaction.TransactionHandler;
 
 import io.vertx.core.AsyncResult;
 import io.vertx.core.Context;
 import io.vertx.core.Handler;
 
 public class TransactionAPI implements FinanceStorageTransactions {
-  private static final String TRANSACTION_TABLE = "transaction";
 
   @Override
   @Validate
@@ -27,8 +31,8 @@ public class TransactionAPI implements FinanceStorageTransactions {
 
   @Override
   @Validate
-  public void postFinanceStorageTransactions(String lang, Transaction entity, Map<String, String> okapiHeaders, Handler<AsyncResult<Response>> asyncResultHandler, Context vertxContext) {
-    PgUtil.post(TRANSACTION_TABLE, entity, okapiHeaders, vertxContext, PostFinanceStorageTransactionsResponse.class, asyncResultHandler);
+  public void postFinanceStorageTransactions(String lang, Transaction transaction, Map<String, String> okapiHeaders, Handler<AsyncResult<Response>> asyncResultHandler, Context vertxContext) {
+    getTransactionHandler(transaction, okapiHeaders, vertxContext, asyncResultHandler).createTransaction(transaction);
   }
 
   @Override
@@ -46,7 +50,16 @@ public class TransactionAPI implements FinanceStorageTransactions {
 
   @Override
   @Validate
-  public void putFinanceStorageTransactionsById(String id, String lang, Transaction entity, Map<String, String> okapiHeaders, Handler<AsyncResult<Response>> asyncResultHandler, Context vertxContext) {
-    PgUtil.put(TRANSACTION_TABLE, entity, id, okapiHeaders, vertxContext, PutFinanceStorageTransactionsByIdResponse.class, asyncResultHandler);
+  public void putFinanceStorageTransactionsById(String id, String lang, Transaction transaction, Map<String, String> okapiHeaders, Handler<AsyncResult<Response>> asyncResultHandler, Context vertxContext) {
+    transaction.setId(id);
+    getTransactionHandler(transaction, okapiHeaders, vertxContext, asyncResultHandler).updateTransaction(transaction);
   }
+
+  private TransactionHandler getTransactionHandler(Transaction transaction, Map<String, String> okapiHeaders, Context vertxContext, Handler<AsyncResult<Response>> asyncResultHandler) {
+    if (transaction.getTransactionType() == Transaction.TransactionType.ENCUMBRANCE) {
+      return new EncumbranceHandler(okapiHeaders, vertxContext, asyncResultHandler);
+    }
+    return new DefaultTransactionHandler(okapiHeaders, vertxContext, asyncResultHandler);
+  }
+
 }

--- a/src/main/java/org/folio/rest/impl/TransactionSummaryAPI.java
+++ b/src/main/java/org/folio/rest/impl/TransactionSummaryAPI.java
@@ -1,27 +1,90 @@
 package org.folio.rest.impl;
 
+import static org.folio.rest.persist.HelperUtils.getFullTableName;
+import static org.folio.rest.persist.PostgresClient.pojo2json;
+
+import java.util.Collections;
 import java.util.Map;
 
 import javax.ws.rs.core.Response;
 
 import org.folio.rest.annotations.Validate;
+import org.folio.rest.jaxrs.model.Error;
+import org.folio.rest.jaxrs.model.Errors;
 import org.folio.rest.jaxrs.model.OrderTransactionSummary;
+import org.folio.rest.jaxrs.model.Parameter;
 import org.folio.rest.jaxrs.resource.FinanceStorageOrderTransactionSummaries;
+import org.folio.rest.persist.PgExceptionUtil;
 import org.folio.rest.persist.PgUtil;
+import org.folio.rest.persist.PostgresClient;
 
 import io.vertx.core.AsyncResult;
 import io.vertx.core.Context;
+import io.vertx.core.Future;
 import io.vertx.core.Handler;
+import io.vertx.core.Vertx;
+import io.vertx.core.json.JsonArray;
+import io.vertx.core.logging.Logger;
+import io.vertx.core.logging.LoggerFactory;
 
 public class TransactionSummaryAPI implements FinanceStorageOrderTransactionSummaries {
-  static final String ORDER_TRANSACTION_SUMMARIES = "order_transaction_summaries";
+
+  private static final Logger log = LoggerFactory.getLogger(TransactionSummaryAPI.class);
+
+  public static final String ORDER_TRANSACTION_SUMMARIES = "order_transaction_summaries";
+  public static final String ORDER_TRANSACTION_SUMMARIES_LOCATION_PREFIX = "/finance-storage/order-transaction-summaries/";
+  private PostgresClient pgClient;
+  private String tenantId;
+
+  public TransactionSummaryAPI(Vertx vertx, String tenantId) {
+    this.tenantId = tenantId;
+    pgClient = PostgresClient.getInstance(vertx, tenantId);
+  }
 
   @Override
   @Validate
-  public void postFinanceStorageOrderTransactionSummaries(OrderTransactionSummary entity, Map<String, String> okapiHeaders,
+  public void postFinanceStorageOrderTransactionSummaries(OrderTransactionSummary summary, Map<String, String> okapiHeaders,
       Handler<AsyncResult<Response>> asyncResultHandler, Context vertxContext) {
-    PgUtil.post(ORDER_TRANSACTION_SUMMARIES, entity, okapiHeaders, vertxContext,
-        PostFinanceStorageOrderTransactionSummariesResponse.class, asyncResultHandler);
+    if (summary.getNumTransactions() < 1) {
+      Parameter parameter = new Parameter().withKey("numTransactions")
+        .withValue(summary.getNumTransactions()
+          .toString());
+      Error error = new Error().withCode("-1")
+        .withMessage("must be greater than or equal to 1")
+        .withParameters(Collections.singletonList(parameter));
+      asyncResultHandler.handle(Future.succeededFuture(PostFinanceStorageOrderTransactionSummariesResponse
+        .respond422WithApplicationJson(new Errors().withErrors(Collections.singletonList(error)))));
+    } else {
+      String sql = "INSERT INTO " + getFullTableName(tenantId, ORDER_TRANSACTION_SUMMARIES)
+          + " (id, jsonb) VALUES (?, ?::JSON) ON CONFLICT (id) DO NOTHING";
+      try {
+        JsonArray params = new JsonArray();
+        params.add(summary.getId());
+        params.add(pojo2json(summary));
+
+        pgClient.execute(sql, params, result -> {
+          if (result.failed()) {
+            String badRequestMessage = PgExceptionUtil.badRequestMessage(result.cause());
+            if (badRequestMessage != null) {
+              asyncResultHandler.handle(Future.succeededFuture(PostFinanceStorageOrderTransactionSummariesResponse
+                .respond400WithTextPlain(Response.Status.BAD_REQUEST.getReasonPhrase())));
+            } else {
+              asyncResultHandler.handle(Future.succeededFuture(PostFinanceStorageOrderTransactionSummariesResponse
+                .respond500WithTextPlain(Response.Status.INTERNAL_SERVER_ERROR.getReasonPhrase())));
+            }
+          } else {
+            log.debug("Preparing response to client");
+            asyncResultHandler.handle(Future.succeededFuture(PostFinanceStorageOrderTransactionSummariesResponse
+              .respond201WithApplicationJson(summary, PostFinanceStorageOrderTransactionSummariesResponse.headersFor201()
+                .withLocation(ORDER_TRANSACTION_SUMMARIES_LOCATION_PREFIX + summary.getId()))));
+          }
+        });
+      } catch (Exception e) {
+        asyncResultHandler.handle(Future.succeededFuture(PostFinanceStorageOrderTransactionSummariesResponse
+          .respond500WithTextPlain(Response.Status.INTERNAL_SERVER_ERROR.getReasonPhrase())));
+      }
+    }
+
   }
 
   @Override

--- a/src/main/java/org/folio/rest/persist/HelperUtils.java
+++ b/src/main/java/org/folio/rest/persist/HelperUtils.java
@@ -92,25 +92,25 @@ public final class HelperUtils {
       .build()));
   }
 
-  public static Criterion getCriterionByFieldNameAndValue(String filedName, String operation, String fieldValue) {
-    return new Criterion(getCriteriaByFieldNameAndValue(filedName, operation, fieldValue));
+  public static Criterion getCriterionByFieldNameAndValue(String fieldName, String operation, String fieldValue) {
+    return new Criterion(getCriteriaByFieldNameAndValue(fieldName, operation, fieldValue));
   }
 
-  public static Criterion getCriterionByFieldNameAndValueNotJsonb(String filedName, String operation, String fieldValue) {
-    return new Criterion(getCriteriaByFieldNameAndValueNotJsonb(filedName, operation, fieldValue));
+  public static Criterion getCriterionByFieldNameAndValueNotJsonb(String fieldName, String operation, String fieldValue) {
+    return new Criterion(getCriteriaByFieldNameAndValueNotJsonb(fieldName, operation, fieldValue));
   }
 
-  public static Criteria getCriteriaByFieldNameAndValue(String filedName, String operation, String fieldValue) {
+  public static Criteria getCriteriaByFieldNameAndValue(String fieldName, String operation, String fieldValue) {
     Criteria a = new Criteria();
-    a.addField("'" + filedName + "'");
+    a.addField("'" + fieldName + "'");
     a.setOperation(operation);
     a.setVal(fieldValue);
     return a;
   }
 
-  public static Criteria getCriteriaByFieldNameAndValueNotJsonb(String filedName, String operation, String fieldValue) {
+  public static Criteria getCriteriaByFieldNameAndValueNotJsonb(String fieldName, String operation, String fieldValue) {
     Criteria a = new Criteria();
-    a.addField(filedName);
+    a.addField(fieldName);
     a.setOperation(operation);
     a.setVal(fieldValue);
     a.setJSONB(false);

--- a/src/main/java/org/folio/rest/transaction/AbstractTransactionHandler.java
+++ b/src/main/java/org/folio/rest/transaction/AbstractTransactionHandler.java
@@ -1,0 +1,53 @@
+package org.folio.rest.transaction;
+
+import static org.folio.rest.tools.utils.TenantTool.tenantId;
+
+import java.util.Map;
+
+import javax.ws.rs.core.Response;
+
+import org.folio.rest.persist.PostgresClient;
+
+import io.vertx.core.AsyncResult;
+import io.vertx.core.Context;
+import io.vertx.core.Handler;
+import io.vertx.core.logging.Logger;
+import io.vertx.core.logging.LoggerFactory;
+
+public abstract class AbstractTransactionHandler implements TransactionHandler {
+
+  protected final Logger log = LoggerFactory.getLogger(this.getClass());
+
+  public static final String TRANSACTION_TABLE = "transaction";
+  static final String TRANSACTION_LOCATION_PREFIX = "/finance-storage/transactions/";
+
+  private final Map<String, String> okapiHeaders;
+  private final Handler<AsyncResult<Response>> asyncResultHandler;
+  private final Context vertxContext;
+
+  AbstractTransactionHandler(Map<String, String> okapiHeaders, Context ctx, Handler<AsyncResult<Response>> handler) {
+    this.okapiHeaders = okapiHeaders;
+    this.vertxContext = ctx;
+    this.asyncResultHandler = handler;
+  }
+
+  String getTenantId() {
+    return tenantId(okapiHeaders);
+  }
+
+  PostgresClient getPostgresClient() {
+    return PostgresClient.getInstance(vertxContext.owner(), getTenantId());
+  }
+
+  public Handler<AsyncResult<Response>> getAsyncResultHandler() {
+    return asyncResultHandler;
+  }
+
+  public Context getVertxContext() {
+    return vertxContext;
+  }
+
+  public Map<String, String> getOkapiHeaders() {
+    return okapiHeaders;
+  }
+}

--- a/src/main/java/org/folio/rest/transaction/AllOrNothingHandler.java
+++ b/src/main/java/org/folio/rest/transaction/AllOrNothingHandler.java
@@ -1,0 +1,202 @@
+package org.folio.rest.transaction;
+
+import static org.folio.rest.persist.HelperUtils.handleFailure;
+import static org.folio.rest.persist.HelperUtils.rollbackTransaction;
+import static org.folio.rest.persist.HelperUtils.startTx;
+
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+import java.util.function.Function;
+
+import javax.ws.rs.core.Response;
+
+import org.folio.rest.jaxrs.model.Transaction;
+import org.folio.rest.jaxrs.resource.FinanceStorageTransactions;
+import org.folio.rest.persist.HelperUtils;
+import org.folio.rest.persist.Tx;
+import org.folio.rest.persist.Criteria.Criterion;
+
+import io.vertx.core.AsyncResult;
+import io.vertx.core.Context;
+import io.vertx.core.Future;
+import io.vertx.core.Handler;
+import io.vertx.core.Promise;
+import io.vertx.core.json.JsonObject;
+import io.vertx.ext.web.handler.impl.HttpStatusException;
+
+public abstract class AllOrNothingHandler extends AbstractTransactionHandler {
+
+  private String temporaryTransactionTable;
+  private String summaryTable;
+  private boolean isLastRecord;
+
+  AllOrNothingHandler(String temporaryTransactionTable, String summaryTable, Map<String, String> okapiHeaders, Context context,
+      Handler<AsyncResult<Response>> handler) {
+    super(okapiHeaders, context, handler);
+    this.temporaryTransactionTable = temporaryTransactionTable;
+    this.summaryTable = summaryTable;
+    this.isLastRecord = false;
+  }
+
+  public void createTransaction(Transaction transaction) {
+    processAllOrNothing(transaction, this::createPermanentTransactions).setHandler(result -> {
+      if (result.failed()) {
+        HttpStatusException cause = (HttpStatusException) result.cause();
+        if (cause.getStatusCode() == Response.Status.BAD_REQUEST.getStatusCode()) {
+          getAsyncResultHandler().handle(Future.succeededFuture(
+              FinanceStorageTransactions.PostFinanceStorageTransactionsResponse.respond400WithTextPlain(cause.getPayload())));
+        } else {
+          getAsyncResultHandler().handle(Future.succeededFuture(FinanceStorageTransactions.PostFinanceStorageTransactionsResponse
+            .respond500WithTextPlain(Response.Status.INTERNAL_SERVER_ERROR.getReasonPhrase())));
+        }
+      } else {
+        log.debug("Preparing response to client");
+        getAsyncResultHandler().handle(
+            Future.succeededFuture(FinanceStorageTransactions.PostFinanceStorageTransactionsResponse.respond201WithApplicationJson(
+                transaction, FinanceStorageTransactions.PostFinanceStorageTransactionsResponse.headersFor201()
+                  .withLocation(TRANSACTION_LOCATION_PREFIX + transaction.getId()))));
+      }
+    });
+  }
+
+  abstract String getId(Transaction transaction);
+
+  abstract Criterion getCriterion(String value);
+
+  private Future<Tx<List<Transaction>>> createPermanentTransactions(Tx<List<Transaction>> tx) {
+    Promise<Tx<List<Transaction>>> promise = Promise.promise();
+    List<Transaction> transactions = tx.getEntity();
+    tx.getPgClient()
+      .saveBatch(tx.getConnection(), TRANSACTION_TABLE, transactions, reply -> {
+        if (reply.failed()) {
+          handleFailure(promise, reply);
+        } else {
+          promise.complete(tx);
+        }
+      });
+    return promise.future();
+  }
+
+  Future<Void> processAllOrNothing(Transaction transaction,
+      Function<Tx<List<Transaction>>, Future<Tx<List<Transaction>>>> processTransaction) {
+    return createTempTransaction(transaction).compose(this::getSummary)
+      .compose(this::getTempTransactions)
+      .compose(transactions -> {
+        Promise<Void> promise = Promise.promise();
+        try {
+          if (isLastRecord) {
+            Tx<List<Transaction>> tx = new Tx<>(transactions, getPostgresClient());
+            startTx(tx).compose(processTransaction)
+              .compose(this::deleteTempTransactions)
+              .compose(HelperUtils::endTx)
+              .setHandler(result -> {
+                if (result.failed()) {
+                  HttpStatusException cause = (HttpStatusException) result.cause();
+                  log.error("Transactions {} or associated data failed to be processed", cause, tx.getEntity());
+
+                  rollbackTransaction(tx).setHandler(res -> promise.fail(cause));
+                } else {
+                  log.info("Transactions {} and associated data were successfully processed", tx.getEntity());
+                  promise.complete();
+                }
+              });
+          } else {
+            promise.complete();
+          }
+        } catch (Exception e) {
+          promise.fail(new HttpStatusException(Response.Status.INTERNAL_SERVER_ERROR.getStatusCode()));
+        }
+        return promise.future();
+      });
+  }
+
+  private Future<Transaction> createTempTransaction(Transaction transaction) {
+    Promise<Transaction> promise = Promise.promise();
+
+    if (transaction.getId() == null) {
+      transaction.setId(UUID.randomUUID()
+        .toString());
+    }
+
+    log.debug("Creating new transaction with id={}", transaction.getId());
+
+    getPostgresClient().save(temporaryTransactionTable, transaction.getId(), transaction, reply -> {
+      if (reply.failed()) {
+        log.error("Transaction creation with id={} failed", reply.cause(), transaction.getId());
+        handleFailure(promise, reply);
+      } else {
+        log.debug("New transaction with id={} successfully created", transaction.getId());
+        promise.complete(transaction);
+      }
+    });
+    return promise.future();
+  }
+
+  private Future<JsonObject> getSummary(Transaction transaction) {
+    Promise<JsonObject> promise = Promise.promise();
+
+    log.debug("Get summary={}", getId(transaction));
+
+    getPostgresClient().getById(summaryTable, getId(transaction), reply -> {
+      if (reply.failed()) {
+        log.error("Summary retrieval with id={} failed", reply.cause(), transaction.getId());
+        handleFailure(promise, reply);
+      } else {
+        log.debug("Summary with id={} successfully extracted", transaction.getId());
+        promise.complete(reply.result());
+      }
+    });
+    return promise.future();
+  }
+
+  private Future<List<Transaction>> getTempTransactions(JsonObject summary) {
+    Promise<List<Transaction>> promise = Promise.promise();
+
+    Criterion criterion = getCriterion(summary.getString("id"));
+
+    getPostgresClient().get(temporaryTransactionTable, Transaction.class, criterion, true, false, reply -> {
+      if (reply.failed()) {
+        log.error("Failed to extract temporary transaction by summary id={}", reply.cause(), summary.getString("id"));
+        handleFailure(promise, reply);
+      } else {
+        List<Transaction> transactions = reply.result()
+          .getResults();
+        isLastRecord = transactions.size() == summary.getInteger("numTransactions");
+        promise.complete(transactions);
+      }
+    });
+    return promise.future();
+  }
+
+  private Future<Tx<List<Transaction>>> deleteTempTransactions(Tx<List<Transaction>> tx) {
+    Promise<Tx<List<Transaction>>> promise = Promise.promise();
+    Transaction transaction = tx.getEntity()
+      .get(0);
+
+    Criterion criterion = getCriterion(getId(transaction));
+
+    tx.getPgClient()
+      .delete(tx.getConnection(), temporaryTransactionTable, criterion, reply -> {
+        if (reply.failed()) {
+          handleFailure(promise, reply);
+        } else {
+          promise.complete(tx);
+        }
+      });
+    return promise.future();
+  }
+
+  String getTemporaryTransactionTable() {
+    return temporaryTransactionTable;
+  }
+
+  String getFullTransactionTableName() {
+    return HelperUtils.getFullTableName(getTenantId(), TRANSACTION_TABLE);
+  }
+
+  String getFullTemporaryTransactionTableName() {
+    return HelperUtils.getFullTableName(getTenantId(), temporaryTransactionTable);
+  }
+
+}

--- a/src/main/java/org/folio/rest/transaction/DefaultTransactionHandler.java
+++ b/src/main/java/org/folio/rest/transaction/DefaultTransactionHandler.java
@@ -1,0 +1,33 @@
+package org.folio.rest.transaction;
+
+import java.util.Map;
+
+import javax.ws.rs.core.Response;
+
+import org.folio.rest.jaxrs.model.Transaction;
+import org.folio.rest.jaxrs.resource.FinanceStorageTransactions;
+import org.folio.rest.persist.PgUtil;
+
+import io.vertx.core.AsyncResult;
+import io.vertx.core.Context;
+import io.vertx.core.Handler;
+
+public class DefaultTransactionHandler extends AbstractTransactionHandler {
+
+  public DefaultTransactionHandler(Map<String, String> okapiHeaders, Context vertxContext,
+      Handler<AsyncResult<Response>> asyncResultHandler) {
+    super(okapiHeaders, vertxContext, asyncResultHandler);
+  }
+
+  @Override
+  public void createTransaction(Transaction transaction) {
+    PgUtil.post(TRANSACTION_TABLE, transaction, getOkapiHeaders(), getVertxContext(),
+        FinanceStorageTransactions.PostFinanceStorageTransactionsResponse.class, getAsyncResultHandler());
+  }
+
+  @Override
+  public void updateTransaction(Transaction transaction) {
+    PgUtil.put(TRANSACTION_TABLE, transaction, transaction.getId(), getOkapiHeaders(), getVertxContext(),
+        FinanceStorageTransactions.PutFinanceStorageTransactionsByIdResponse.class, getAsyncResultHandler());
+  }
+}

--- a/src/main/java/org/folio/rest/transaction/EncumbranceHandler.java
+++ b/src/main/java/org/folio/rest/transaction/EncumbranceHandler.java
@@ -59,14 +59,14 @@ public class EncumbranceHandler extends AllOrNothingHandler {
   }
 
   @Override
-  String getId(Transaction transaction) {
+  String getSummaryId(Transaction transaction) {
     return transaction.getEncumbrance()
       .getSourcePurchaseOrderId();
   }
 
   @Override
-  Criterion getCriterion(String value) {
-    return getCriterionByFieldNameAndValueNotJsonb("encumbrance_sourcepurchaseorderid", "=", value);
+  Criterion getTransactionBySummaryIdCriterion(String value) {
+    return getCriterionByFieldNameAndValueNotJsonb("encumbrance_sourcePurchaseOrderId", "=", value);
   }
 
   private Future<Tx<List<Transaction>>> updatePermanentTransactions(Tx<List<Transaction>> tx) {
@@ -78,7 +78,7 @@ public class EncumbranceHandler extends AllOrNothingHandler {
     String sql = "UPDATE " + getFullTransactionTableName() + " SET jsonb = (SELECT jsonb " + "FROM "
         + getTemporaryTransactionTable() + " WHERE " + getFullTransactionTableName() + ".id = "
         + getFullTemporaryTransactionTableName() + ".id) " + "WHERE id IN (SELECT id FROM " + getFullTemporaryTransactionTableName()
-        + " WHERE encumbrance_sourcepurchaseorderid = '" + sourcePurchaseOrderId + "');";
+        + " WHERE encumbrance_sourcePurchaseOrderId = '" + sourcePurchaseOrderId + "');";
     tx.getPgClient()
       .execute(tx.getConnection(), sql, reply -> {
         if (reply.failed()) {

--- a/src/main/java/org/folio/rest/transaction/EncumbranceHandler.java
+++ b/src/main/java/org/folio/rest/transaction/EncumbranceHandler.java
@@ -1,0 +1,107 @@
+package org.folio.rest.transaction;
+
+import static org.folio.rest.impl.TransactionSummaryAPI.ORDER_TRANSACTION_SUMMARIES;
+import static org.folio.rest.persist.HelperUtils.getCriterionByFieldNameAndValueNotJsonb;
+import static org.folio.rest.persist.HelperUtils.handleFailure;
+
+import java.util.List;
+import java.util.Map;
+
+import javax.ws.rs.core.Response;
+
+import org.folio.rest.jaxrs.model.Transaction;
+import org.folio.rest.jaxrs.resource.FinanceStorageTransactions;
+import org.folio.rest.persist.Tx;
+import org.folio.rest.persist.Criteria.Criterion;
+
+import io.vertx.core.AsyncResult;
+import io.vertx.core.Context;
+import io.vertx.core.Future;
+import io.vertx.core.Handler;
+import io.vertx.core.Promise;
+import io.vertx.ext.web.handler.impl.HttpStatusException;
+
+public class EncumbranceHandler extends AllOrNothingHandler {
+
+  private static final String TEMPORARY_ORDER_TRANSACTIONS = "temporary_order_transactions";
+
+  public EncumbranceHandler(Map<String, String> okapiHeaders, Context ctx, Handler<AsyncResult<Response>> asyncResultHandler) {
+    super(TEMPORARY_ORDER_TRANSACTIONS, ORDER_TRANSACTION_SUMMARIES, okapiHeaders, ctx, asyncResultHandler);
+  }
+
+  @Override
+  public void updateTransaction(Transaction transaction) {
+    verifyTransactionExistence(transaction.getId())
+      .compose(aVoid -> processAllOrNothing(transaction, this::updatePermanentTransactions))
+      .setHandler(result -> {
+        if (result.failed()) {
+          HttpStatusException cause = (HttpStatusException) result.cause();
+          switch (cause.getStatusCode()) {
+          case 400:
+            getAsyncResultHandler().handle(Future.succeededFuture(
+                FinanceStorageTransactions.PutFinanceStorageTransactionsByIdResponse.respond400WithTextPlain(cause.getPayload())));
+            break;
+          case 404:
+            getAsyncResultHandler().handle(Future.succeededFuture(
+                FinanceStorageTransactions.PutFinanceStorageTransactionsByIdResponse.respond404WithTextPlain(cause.getPayload())));
+            break;
+          default:
+            getAsyncResultHandler()
+              .handle(Future.succeededFuture(FinanceStorageTransactions.PutFinanceStorageTransactionsByIdResponse
+                .respond500WithTextPlain(Response.Status.INTERNAL_SERVER_ERROR.getReasonPhrase())));
+          }
+        } else {
+          log.debug("Preparing response to client");
+          getAsyncResultHandler()
+            .handle(Future.succeededFuture(FinanceStorageTransactions.PutFinanceStorageTransactionsByIdResponse.respond204()));
+        }
+      });
+  }
+
+  @Override
+  String getId(Transaction transaction) {
+    return transaction.getEncumbrance()
+      .getSourcePurchaseOrderId();
+  }
+
+  @Override
+  Criterion getCriterion(String value) {
+    return getCriterionByFieldNameAndValueNotJsonb("encumbrance_sourcepurchaseorderid", "=", value);
+  }
+
+  private Future<Tx<List<Transaction>>> updatePermanentTransactions(Tx<List<Transaction>> tx) {
+    Promise<Tx<List<Transaction>>> promise = Promise.promise();
+    String sourcePurchaseOrderId = tx.getEntity()
+      .get(0)
+      .getEncumbrance()
+      .getSourcePurchaseOrderId();
+    String sql = "UPDATE " + getFullTransactionTableName() + " SET jsonb = (SELECT jsonb " + "FROM "
+        + getTemporaryTransactionTable() + " WHERE " + getFullTransactionTableName() + ".id = "
+        + getFullTemporaryTransactionTableName() + ".id) " + "WHERE id IN (SELECT id FROM " + getFullTemporaryTransactionTableName()
+        + " WHERE encumbrance_sourcepurchaseorderid = '" + sourcePurchaseOrderId + "');";
+    tx.getPgClient()
+      .execute(tx.getConnection(), sql, reply -> {
+        if (reply.failed()) {
+          handleFailure(promise, reply);
+        } else {
+          promise.complete(tx);
+        }
+      });
+    return promise.future();
+  }
+
+  private Future<Void> verifyTransactionExistence(String transactionId) {
+    Promise<Void> promise = Promise.promise();
+    getPostgresClient().getById(TRANSACTION_TABLE, transactionId, reply -> {
+      if (reply.failed()) {
+        handleFailure(promise, reply);
+      } else if (reply.result() == null) {
+        promise.fail(new HttpStatusException(Response.Status.NOT_FOUND.getStatusCode(), "Not found"));
+      } else {
+        promise.complete();
+      }
+    });
+    return promise.future();
+  }
+
+}

--- a/src/main/java/org/folio/rest/transaction/TransactionHandler.java
+++ b/src/main/java/org/folio/rest/transaction/TransactionHandler.java
@@ -1,0 +1,10 @@
+package org.folio.rest.transaction;
+
+import org.folio.rest.jaxrs.model.Transaction;
+
+public interface TransactionHandler {
+
+  void createTransaction(Transaction transaction);
+
+  void updateTransaction(Transaction transaction);
+}

--- a/src/main/resources/data/order-transaction-summaries/order-transaction-summary.json
+++ b/src/main/resources/data/order-transaction-summaries/order-transaction-summary.json
@@ -1,0 +1,4 @@
+{
+  "id": "e5ae4afd-3fa9-494e-a972-f541df9b877e",
+  "numTransactions": 1
+}

--- a/src/main/resources/data/transactions/allocation.json
+++ b/src/main/resources/data/transactions/allocation.json
@@ -9,11 +9,6 @@
   "source": "Voucher",
   "sourceFiscalYearId": "684b5dc5-92f6-4db7-b996-b549d88f5e4e",
   "sourceInvoiceId": "041c1fe8-adfa-44eb-b6b3-f85acdd71f81",
-  "tags": {
-    "tagList": [
-      "important"
-    ]
-  },
   "toFundId": "69640328-788e-43fc-9c3c-af39e243f3b7",
   "transactionType": "Allocation"
 }

--- a/src/main/resources/data/transactions/credit.json
+++ b/src/main/resources/data/transactions/credit.json
@@ -10,11 +10,6 @@
   "sourceFiscalYearId": "684b5dc5-92f6-4db7-b996-b549d88f5e4e",
   "sourceInvoiceId": "041c1fe8-adfa-44eb-b6b3-f85acdd71f81",
   "sourceInvoiceLineId": "ee60ee78-f487-4940-adcf-fa0726989823",
-  "tags": {
-    "tagList": [
-      "important"
-    ]
-  },
   "toFundId": "69640328-788e-43fc-9c3c-af39e243f3b7",
   "transactionType": "Credit"
 }

--- a/src/main/resources/data/transactions/encumbrance.json
+++ b/src/main/resources/data/transactions/encumbrance.json
@@ -20,11 +20,6 @@
   "source": "Voucher",
   "sourceFiscalYearId": "684b5dc5-92f6-4db7-b996-b549d88f5e4e",
   "sourceInvoiceId": "041c1fe8-adfa-44eb-b6b3-f85acdd71f81",
-  "tags": {
-    "tagList": [
-      "important"
-    ]
-  },
   "toFundId": "69640328-788e-43fc-9c3c-af39e243f3b7",
   "transactionType": "Encumbrance"
 }

--- a/src/main/resources/data/transactions/payment.json
+++ b/src/main/resources/data/transactions/payment.json
@@ -9,10 +9,5 @@
   "sourceFiscalYearId": "684b5dc5-92f6-4db7-b996-b549d88f5e4e",
   "sourceInvoiceId": "041c1fe8-adfa-44eb-b6b3-f85acdd71f81",
   "sourceInvoiceLineId": "ee60ee78-f487-4940-adcf-fa0726989823",
-  "tags": {
-    "tagList": [
-      "important"
-    ]
-  },
   "transactionType": "Payment"
 }

--- a/src/main/resources/data/transactions/transfer.json
+++ b/src/main/resources/data/transactions/transfer.json
@@ -9,11 +9,6 @@
   "source": "Voucher",
   "sourceFiscalYearId": "684b5dc5-92f6-4db7-b996-b549d88f5e4e",
   "sourceInvoiceId": "041c1fe8-adfa-44eb-b6b3-f85acdd71f81",
-  "tags": {
-    "tagList": [
-      "important"
-    ]
-  },
   "toFundId": "69640328-788e-43fc-9c3c-af39e243f3b7",
   "transactionType": "Transfer"
 }

--- a/src/main/resources/templates/db_scripts/schema.json
+++ b/src/main/resources/templates/db_scripts/schema.json
@@ -278,7 +278,7 @@
       "customSnippetPath": "transactions.sql",
       "uniqueIndex": [
         {
-          "fieldName": "amount, fromFundId, encumbrance.sourcePurchaseOrderId, encumbrance.sourcePoLineId, encumbrance.initialAmountEncumbered, toFundId, transactionType",
+          "fieldName": "amount, fromFundId, encumbrance.sourcePurchaseOrderId, encumbrance.sourcePoLineId, encumbrance.initialAmountEncumbered, encumbrance.status",
           "tOps": "ADD",
           "whereClause": "WHERE (jsonb->>'transactionType')::text = 'Encumbrance'"
         }
@@ -455,7 +455,7 @@
       ],
       "uniqueIndex": [
         {
-          "fieldName": "amount, fromFundId, encumbrance.sourcePurchaseOrderId, encumbrance.sourcePoLineId, encumbrance.initialAmountEncumbered, toFundId, transactionType",
+          "fieldName": "amount, fromFundId, encumbrance.sourcePurchaseOrderId, encumbrance.sourcePoLineId, encumbrance.initialAmountEncumbered, encumbrance.status",
           "tOps": "ADD"
         }
       ]

--- a/src/main/resources/templates/db_scripts/schema.json
+++ b/src/main/resources/templates/db_scripts/schema.json
@@ -237,6 +237,13 @@
       "fromModuleVersion": "mod-finance-storage-4.0.0",
       "withMetadata": true,
       "customSnippetPath": "transactions.sql",
+      "uniqueIndex": [
+        {
+          "fieldName": "amount, fromFundId, encumbrance.sourcePurchaseOrderId, encumbrance.sourcePoLineId, encumbrance.initialAmountEncumbered, toFundId, transactionType",
+          "tOps": "ADD",
+          "whereClause": "WHERE (jsonb->>'transactionType')::text = 'Encumbrance'"
+        }
+      ],
       "foreignKeys": [
         {
           "fieldName": "fiscalYearId",
@@ -404,6 +411,12 @@
         {
           "fieldName": "encumbrance.sourcePurchaseOrderId",
           "targetTable": "order_transaction_summaries",
+          "tOps": "ADD"
+        }
+      ],
+      "uniqueIndex": [
+        {
+          "fieldName": "amount, fromFundId, encumbrance.sourcePurchaseOrderId, encumbrance.sourcePoLineId, encumbrance.initialAmountEncumbered, toFundId, transactionType",
           "tOps": "ADD"
         }
       ]

--- a/src/test/java/org/folio/rest/impl/TenantSampleDataTest.java
+++ b/src/test/java/org/folio/rest/impl/TenantSampleDataTest.java
@@ -1,18 +1,5 @@
 package org.folio.rest.impl;
 
-import io.restassured.http.ContentType;
-import io.restassured.http.Header;
-import io.restassured.response.Response;
-import io.vertx.core.json.JsonObject;
-import io.vertx.core.logging.Logger;
-import io.vertx.core.logging.LoggerFactory;
-import org.folio.rest.jaxrs.model.Budget;
-import org.folio.rest.jaxrs.model.BudgetCollection;
-import org.folio.rest.utils.TestEntities;
-import org.junit.jupiter.api.Test;
-
-import java.net.MalformedURLException;
-
 import static io.restassured.RestAssured.given;
 import static org.folio.rest.RestVerticle.OKAPI_HEADER_TENANT;
 import static org.folio.rest.impl.StorageTestSuite.storageUrl;
@@ -23,6 +10,20 @@ import static org.folio.rest.utils.TenantApiTestUtil.prepareTenant;
 import static org.folio.rest.utils.TenantApiTestUtil.prepareTenantBody;
 import static org.folio.rest.utils.TestEntities.BUDGET;
 import static org.folio.rest.utils.TestEntities.FUND_TYPE;
+
+import java.net.MalformedURLException;
+
+import org.folio.rest.jaxrs.model.Budget;
+import org.folio.rest.jaxrs.model.BudgetCollection;
+import org.folio.rest.utils.TestEntities;
+import org.junit.jupiter.api.Test;
+
+import io.restassured.http.ContentType;
+import io.restassured.http.Header;
+import io.restassured.response.Response;
+import io.vertx.core.json.JsonObject;
+import io.vertx.core.logging.Logger;
+import io.vertx.core.logging.LoggerFactory;
 
 
 public class TenantSampleDataTest extends TestBase {
@@ -99,7 +100,6 @@ public class TenantSampleDataTest extends TestBase {
           .response();
 
       BudgetCollection budgetCollection = new JsonObject(response.asString()).mapTo(BudgetCollection.class);
-      //BudgetCollection budgetCollection = response.as(BudgetCollection.class);
 
       for (Budget budget : budgetCollection.getBudgets()) {
         deleteData(BUDGET.getEndpointWithId(), budget.getId(), PARTIAL_TENANT_HEADER);

--- a/src/test/java/org/folio/rest/impl/TestBase.java
+++ b/src/test/java/org/folio/rest/impl/TestBase.java
@@ -1,5 +1,26 @@
 package org.folio.rest.impl;
 
+import static io.restassured.RestAssured.given;
+import static org.folio.rest.RestVerticle.OKAPI_HEADER_TENANT;
+import static org.folio.rest.impl.StorageTestSuite.storageUrl;
+import static org.hamcrest.Matchers.equalTo;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertThat;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.net.MalformedURLException;
+import java.util.Set;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeoutException;
+
+import javax.ws.rs.Path;
+
+import org.apache.commons.io.IOUtils;
+import org.folio.rest.utils.TestEntities;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+
 import io.restassured.http.ContentType;
 import io.restassured.http.Header;
 import io.restassured.response.Response;
@@ -8,26 +29,6 @@ import io.vertx.core.Vertx;
 import io.vertx.core.json.JsonObject;
 import io.vertx.core.logging.Logger;
 import io.vertx.core.logging.LoggerFactory;
-
-import org.apache.commons.io.IOUtils;
-import org.folio.rest.utils.TestEntities;
-import org.junit.jupiter.api.AfterAll;
-import org.junit.jupiter.api.BeforeAll;
-import java.io.IOException;
-import java.io.InputStream;
-import java.net.MalformedURLException;
-import java.util.Set;
-import java.util.concurrent.ExecutionException;
-import java.util.concurrent.TimeoutException;
-
-import static io.restassured.RestAssured.given;
-import static org.folio.rest.RestVerticle.OKAPI_HEADER_TENANT;
-import static org.folio.rest.impl.StorageTestSuite.storageUrl;
-import static org.hamcrest.Matchers.equalTo;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertThat;
-
-import javax.ws.rs.Path;
 
 /**
  * When not run from StorageTestSuite then this class invokes StorageTestSuite.before() and
@@ -120,11 +121,7 @@ public abstract class TestBase {
   }
 
   Response getDataById(String endpoint, String id) throws MalformedURLException {
-    return given()
-      .pathParam("id", id)
-      .header(TENANT_HEADER)
-      .contentType(ContentType.JSON)
-      .get(storageUrl(endpoint));
+    return getDataById(endpoint, id, TENANT_HEADER);
   }
 
   Response getDataById(String endpoint, String id, Header header) throws MalformedURLException {
@@ -135,13 +132,17 @@ public abstract class TestBase {
       .get(storageUrl(endpoint));
   }
 
-  Response putData(String endpoint, String id, String input) throws MalformedURLException {
+  Response putData(String endpoint, String id, String input, Header tenant) throws MalformedURLException {
     return given()
       .pathParam("id", id)
-      .header(TENANT_HEADER)
+      .header(tenant)
       .contentType(ContentType.JSON)
       .body(input)
       .put(storageUrl(endpoint));
+  }
+
+  Response putData(String endpoint, String id, String input) throws MalformedURLException {
+    return putData(endpoint, id, input, TENANT_HEADER);
   }
 
   void deleteDataSuccess(String endpoint, String id) throws MalformedURLException {

--- a/src/test/java/org/folio/rest/impl/TransactionTest.java
+++ b/src/test/java/org/folio/rest/impl/TransactionTest.java
@@ -3,23 +3,28 @@ package org.folio.rest.impl;
 import static io.restassured.RestAssured.given;
 import static org.folio.rest.RestVerticle.OKAPI_HEADER_TENANT;
 import static org.folio.rest.impl.StorageTestSuite.storageUrl;
+import static org.folio.rest.impl.TransactionsSummariesTest.ORDER_TRANSACTION_SUMMARIES_ENDPOINT;
 import static org.folio.rest.utils.TenantApiTestUtil.deleteTenant;
 import static org.folio.rest.utils.TenantApiTestUtil.prepareTenant;
 import static org.folio.rest.utils.TestEntities.BUDGET;
 import static org.folio.rest.utils.TestEntities.GROUP_FUND_FY;
 import static org.folio.rest.utils.TestEntities.LEDGER;
 import static org.folio.rest.utils.TestEntities.TRANSACTION;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.hasSize;
+import static org.hamcrest.core.IsEqual.equalTo;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import java.math.BigDecimal;
 import java.net.MalformedURLException;
+import java.util.UUID;
 
 import org.apache.commons.lang3.StringUtils;
 import org.folio.rest.jaxrs.model.Budget;
 import org.folio.rest.jaxrs.model.BudgetCollection;
 import org.folio.rest.jaxrs.model.Ledger;
 import org.folio.rest.jaxrs.model.LedgerCollection;
+import org.folio.rest.jaxrs.model.OrderTransactionSummary;
 import org.folio.rest.jaxrs.model.Transaction;
 import org.junit.jupiter.api.Test;
 
@@ -292,17 +297,22 @@ class TransactionTest extends TestBase {
 
 
   @Test
-  void testCreateEncumbrance() throws MalformedURLException {
+  void testCreateEncumbranceAllOrNothing() throws MalformedURLException {
     prepareTenant(TRANSACTION_TENANT_HEADER, true, true);
     verifyCollectionQuantity(TRANSACTION_ENDPOINT, TRANSACTION.getInitialQuantity(), TRANSACTION_TENANT_HEADER);
-
+    String orderId = UUID.randomUUID().toString();
+    OrderTransactionSummary summary = new OrderTransactionSummary().withId(orderId).withNumTransactions(2);
+    postData(ORDER_TRANSACTION_SUMMARIES_ENDPOINT, JsonObject.mapFrom(summary)
+        .encodePrettily(), TRANSACTION_TENANT_HEADER).as(OrderTransactionSummary.class);
     JsonObject jsonTx = new JsonObject(getFile("data/transactions/encumbrance.json"));
     jsonTx.remove("id");
-    String transactionSample = jsonTx.toString();
+    Transaction encumbrance = jsonTx.mapTo(Transaction.class);
 
-    String fY = jsonTx.getString("fiscalYearId");
-    String fromFundId = jsonTx.getString("fromFundId");
+    encumbrance.getEncumbrance().setSourcePurchaseOrderId(orderId);
+    String fY = encumbrance.getFiscalYearId();
+    String fromFundId = encumbrance.getFromFundId();
 
+    String transactionSample = JsonObject.mapFrom(encumbrance).encodePrettily();
     // prepare budget/ledger queries
     String fromBudgetEndpointWithQueryParams = String.format(BUDGETS_QUERY, fY, fromFundId);
     String fromLedgerEndpointWithQueryParams = String.format(LEDGERS_QUERY, fromFundId);
@@ -311,17 +321,33 @@ class TransactionTest extends TestBase {
     Budget fromBudgetBefore = getBudgetAndValidate(fromBudgetEndpointWithQueryParams);
     Ledger fromLedgerBefore = getLedgerAndValidate(fromLedgerEndpointWithQueryParams);
 
-    // create Encumbrance
-    postData(TRANSACTION_ENDPOINT, transactionSample, TRANSACTION_TENANT_HEADER).then()
+    // create 1st Encumbrance, expected number is 2
+    String encumbrance1Id = postData(TRANSACTION_ENDPOINT, transactionSample, TRANSACTION_TENANT_HEADER).then()
       .statusCode(201)
       .extract()
-      .as(Transaction.class);
+      .as(Transaction.class).getId();
+
+    // encumbrance do not appear in transaction table
+    getDataById(TRANSACTION.getEndpointWithId(), encumbrance1Id, TRANSACTION_TENANT_HEADER).then().statusCode(404);
+
+    encumbrance.getEncumbrance().setSourcePoLineId(UUID.randomUUID().toString());
+    transactionSample = JsonObject.mapFrom(encumbrance).encodePrettily();
+
+    // create 2nd Encumbrance
+    String encumbrance2Id = postData(TRANSACTION_ENDPOINT, transactionSample, TRANSACTION_TENANT_HEADER).then()
+      .statusCode(201)
+      .extract()
+      .as(Transaction.class).getId();
+
+    // 2 encumbrances appear in transaction table
+    getDataById(TRANSACTION.getEndpointWithId(), encumbrance1Id, TRANSACTION_TENANT_HEADER).then().statusCode(200).extract().as(Transaction.class);
+    getDataById(TRANSACTION.getEndpointWithId(), encumbrance2Id, TRANSACTION_TENANT_HEADER).then().statusCode(200).extract().as(Transaction.class);
 
     Budget fromBudgetAfter = getBudgetAndValidate(fromBudgetEndpointWithQueryParams);
     Ledger fromLedgerAfter = getLedgerAndValidate(fromLedgerEndpointWithQueryParams);
 
     // check source budget and ledger totals
-    final Double amount = jsonTx.getDouble("amount");
+    final Double amount = sumValues(encumbrance.getAmount(), encumbrance.getAmount()); //2 encumbrances with same amount were created
     double expectedBudgetsAvailable;
     double expectedBudgetsUnavailable;
     double expectedBudgetsEncumbered;
@@ -347,6 +373,207 @@ class TransactionTest extends TestBase {
     // cleanup
     deleteTenant(TRANSACTION_TENANT_HEADER);
   }
+
+  @Test
+  void testCreateEncumbranceWithoutSummary() throws MalformedURLException {
+    prepareTenant(TRANSACTION_TENANT_HEADER, true, true);
+    verifyCollectionQuantity(TRANSACTION_ENDPOINT, TRANSACTION.getInitialQuantity(), TRANSACTION_TENANT_HEADER);
+    String orderId = UUID.randomUUID().toString();
+
+    JsonObject jsonTx = new JsonObject(getFile("data/transactions/encumbrance.json"));
+    jsonTx.remove("id");
+    Transaction encumbrance = jsonTx.mapTo(Transaction.class);
+
+    encumbrance.getEncumbrance().setSourcePurchaseOrderId(orderId);
+
+    String transactionSample = JsonObject.mapFrom(encumbrance).encodePrettily();
+
+    postData(TRANSACTION_ENDPOINT, transactionSample, TRANSACTION_TENANT_HEADER).then()
+      .statusCode(400);
+
+    // cleanup
+    deleteTenant(TRANSACTION_TENANT_HEADER);
+  }
+
+  @Test
+  void testCreateEncumbrancesDuplicateInTemporaryTable() throws MalformedURLException {
+    prepareTenant(TRANSACTION_TENANT_HEADER, true, true);
+    verifyCollectionQuantity(TRANSACTION_ENDPOINT, TRANSACTION.getInitialQuantity(), TRANSACTION_TENANT_HEADER);
+    String orderId = UUID.randomUUID().toString();
+
+    OrderTransactionSummary summary = new OrderTransactionSummary().withId(orderId).withNumTransactions(2);
+    postData(ORDER_TRANSACTION_SUMMARIES_ENDPOINT, JsonObject.mapFrom(summary)
+      .encodePrettily(), TRANSACTION_TENANT_HEADER).as(OrderTransactionSummary.class);
+    JsonObject jsonTx = new JsonObject(getFile("data/transactions/encumbrance.json"));
+    jsonTx.remove("id");
+    Transaction encumbrance = jsonTx.mapTo(Transaction.class);
+
+    encumbrance.getEncumbrance().setSourcePurchaseOrderId(orderId);
+
+    String transactionSample = JsonObject.mapFrom(encumbrance).encodePrettily();
+
+    String encumbrance1Id = postData(TRANSACTION_ENDPOINT, transactionSample, TRANSACTION_TENANT_HEADER).then()
+      .statusCode(201).extract().as(Transaction.class).getId();
+
+    // encumbrance do not appear in transaction table
+    getDataById(TRANSACTION.getEndpointWithId(), encumbrance1Id, TRANSACTION_TENANT_HEADER).then().statusCode(404);
+
+    postData(TRANSACTION_ENDPOINT, transactionSample, TRANSACTION_TENANT_HEADER).then()
+      .statusCode(400);
+
+    // cleanup
+    deleteTenant(TRANSACTION_TENANT_HEADER);
+  }
+
+  @Test
+  void testCreateEncumbrancesDuplicateInTransactionTable() throws MalformedURLException {
+    prepareTenant(TRANSACTION_TENANT_HEADER, true, true);
+    verifyCollectionQuantity(TRANSACTION_ENDPOINT, TRANSACTION.getInitialQuantity(), TRANSACTION_TENANT_HEADER);
+
+    String orderId = UUID.randomUUID().toString();
+    OrderTransactionSummary summary = new OrderTransactionSummary().withId(orderId).withNumTransactions(2);
+
+    postData(ORDER_TRANSACTION_SUMMARIES_ENDPOINT, JsonObject.mapFrom(summary)
+      .encodePrettily(), TRANSACTION_TENANT_HEADER).as(OrderTransactionSummary.class);
+
+    JsonObject jsonTx = new JsonObject(getFile("data/transactions/encumbrance.json"));
+    jsonTx.remove("id");
+
+    Transaction encumbrance1 = jsonTx.mapTo(Transaction.class);
+    encumbrance1.getEncumbrance().setSourcePurchaseOrderId(orderId);
+
+    Transaction encumbrance2 = jsonTx.mapTo(Transaction.class);
+    encumbrance2.getEncumbrance().setSourcePurchaseOrderId(orderId);
+    encumbrance2.getEncumbrance().setSourcePoLineId(UUID.randomUUID().toString());
+
+    String transactionSample1 = JsonObject.mapFrom(encumbrance1).encodePrettily();
+
+    // create 1st Encumbrance, expected number is 2
+    String encumbrance1Id = postData(TRANSACTION_ENDPOINT, transactionSample1, TRANSACTION_TENANT_HEADER).then()
+      .statusCode(201)
+      .extract()
+      .as(Transaction.class).getId();
+
+    // encumbrance do not appear in transaction table
+    getDataById(TRANSACTION.getEndpointWithId(), encumbrance1Id, TRANSACTION_TENANT_HEADER).then().statusCode(404);
+
+
+    String transactionSample2 = JsonObject.mapFrom(encumbrance2).encodePrettily();
+
+    // create 2nd Encumbrance
+    String encumbrance2Id = postData(TRANSACTION_ENDPOINT, transactionSample2, TRANSACTION_TENANT_HEADER).then()
+      .statusCode(201)
+      .extract()
+      .as(Transaction.class).getId();
+
+    // 2 encumbrances appear in transaction table, temp transaction deleted
+    getDataById(TRANSACTION.getEndpointWithId(), encumbrance1Id, TRANSACTION_TENANT_HEADER).then().statusCode(200).extract().as(Transaction.class);
+    getDataById(TRANSACTION.getEndpointWithId(), encumbrance2Id, TRANSACTION_TENANT_HEADER).then().statusCode(200).extract().as(Transaction.class);
+
+    encumbrance1Id = postData(TRANSACTION_ENDPOINT, transactionSample1, TRANSACTION_TENANT_HEADER).then()
+      .statusCode(201)
+      .extract()
+      .as(Transaction.class).getId();
+
+    // encumbrance do not appear in transaction table
+    getDataById(TRANSACTION.getEndpointWithId(), encumbrance1Id, TRANSACTION_TENANT_HEADER).then().statusCode(404);
+
+    // create 2nd Encumbrance
+    postData(TRANSACTION_ENDPOINT, transactionSample2, TRANSACTION_TENANT_HEADER)
+      .then()
+      .statusCode(400);
+
+    // cleanup
+    deleteTenant(TRANSACTION_TENANT_HEADER);
+  }
+
+  @Test
+  void testUpdateEncumbranceAllOrNothing() throws MalformedURLException {
+    prepareTenant(TRANSACTION_TENANT_HEADER, true, true);
+    verifyCollectionQuantity(TRANSACTION_ENDPOINT, TRANSACTION.getInitialQuantity(), TRANSACTION_TENANT_HEADER);
+
+    String orderId = UUID.randomUUID().toString();
+    OrderTransactionSummary summary = new OrderTransactionSummary().withId(orderId).withNumTransactions(2);
+    postData(ORDER_TRANSACTION_SUMMARIES_ENDPOINT, JsonObject.mapFrom(summary)
+      .encodePrettily(), TRANSACTION_TENANT_HEADER).as(OrderTransactionSummary.class);
+
+    JsonObject jsonTx = new JsonObject(getFile("data/transactions/encumbrance.json"));
+    jsonTx.remove("id");
+    Transaction encumbrance1 = jsonTx.mapTo(Transaction.class);
+    encumbrance1.getEncumbrance().setSourcePurchaseOrderId(orderId);
+    final String initialDescription = "Initial description";
+    final String newDescription = "New description";
+
+    encumbrance1.setDescription(initialDescription);
+
+    Transaction encumbrance2 = jsonTx.mapTo(Transaction.class);
+    encumbrance2.getEncumbrance().setSourcePurchaseOrderId(orderId);
+    encumbrance2.getEncumbrance().setSourcePoLineId(UUID.randomUUID().toString());
+    encumbrance2.setDescription(initialDescription);
+
+    String transactionSample = JsonObject.mapFrom(encumbrance1).encodePrettily();
+
+    // create 1st Encumbrance, expected number is 2
+    String encumbrance1Id = postData(TRANSACTION_ENDPOINT, transactionSample, TRANSACTION_TENANT_HEADER).then()
+      .statusCode(201)
+      .extract()
+      .as(Transaction.class).getId();
+
+    // encumbrance do not appear in transaction table
+    getDataById(TRANSACTION.getEndpointWithId(), encumbrance1Id, TRANSACTION_TENANT_HEADER).then().statusCode(404);
+
+    transactionSample = JsonObject.mapFrom(encumbrance2).encodePrettily();
+
+    // create 2nd Encumbrance
+    String encumbrance2Id = postData(TRANSACTION_ENDPOINT, transactionSample, TRANSACTION_TENANT_HEADER).then()
+      .statusCode(201)
+      .extract()
+      .as(Transaction.class).getId();
+
+    // 2 encumbrances appear in transaction table
+    getDataById(TRANSACTION.getEndpointWithId(), encumbrance1Id, TRANSACTION_TENANT_HEADER).then().statusCode(200).extract().as(Transaction.class);
+    getDataById(TRANSACTION.getEndpointWithId(), encumbrance2Id, TRANSACTION_TENANT_HEADER).then().statusCode(200).extract().as(Transaction.class);
+
+    encumbrance1.setDescription(newDescription);
+    encumbrance2.setDescription(newDescription);
+
+    // First encumbrance update, save to temp table, changes won't get to transaction table
+    putData(TRANSACTION.getEndpointWithId(), encumbrance1Id, JsonObject.mapFrom(encumbrance1).encodePrettily(), TRANSACTION_TENANT_HEADER).then().statusCode(204);
+    Transaction transaction1FromStorage = getDataById(TRANSACTION.getEndpointWithId(), encumbrance1Id, TRANSACTION_TENANT_HEADER).then().statusCode(200).extract().as(Transaction.class);
+    assertThat(transaction1FromStorage.getDescription(), equalTo(initialDescription));
+
+    // Second encumbrance update, changes for two encumbrances will get to transaction table
+    putData(TRANSACTION.getEndpointWithId(), encumbrance2Id, JsonObject.mapFrom(encumbrance2).encodePrettily(), TRANSACTION_TENANT_HEADER).then().statusCode(204);
+    transaction1FromStorage = getDataById(TRANSACTION.getEndpointWithId(), encumbrance1Id, TRANSACTION_TENANT_HEADER).then().statusCode(200).extract().as(Transaction.class);
+    Transaction transaction2FromStorage = getDataById(TRANSACTION.getEndpointWithId(), encumbrance2Id, TRANSACTION_TENANT_HEADER).then().statusCode(200).extract().as(Transaction.class);
+    assertThat(transaction1FromStorage.getDescription(), equalTo(newDescription));
+    assertThat(transaction2FromStorage.getDescription(), equalTo(newDescription));
+    // cleanup
+    deleteTenant(TRANSACTION_TENANT_HEADER);
+  }
+
+
+  @Test
+  void testUpdateEncumbranceAllNotFound() throws MalformedURLException {
+    prepareTenant(TRANSACTION_TENANT_HEADER, true, true);
+    verifyCollectionQuantity(TRANSACTION_ENDPOINT, TRANSACTION.getInitialQuantity(), TRANSACTION_TENANT_HEADER);
+
+    String orderId = UUID.randomUUID().toString();
+    OrderTransactionSummary summary = new OrderTransactionSummary().withId(orderId).withNumTransactions(2);
+    postData(ORDER_TRANSACTION_SUMMARIES_ENDPOINT, JsonObject.mapFrom(summary)
+      .encodePrettily(), TRANSACTION_TENANT_HEADER).as(OrderTransactionSummary.class);
+
+    JsonObject jsonTx = new JsonObject(getFile("data/transactions/encumbrance.json"));
+    jsonTx.remove("id");
+    Transaction encumbrance = jsonTx.mapTo(Transaction.class);
+    encumbrance.getEncumbrance().setSourcePurchaseOrderId(orderId);
+
+    // Try to update non-existent transaction
+    putData(TRANSACTION.getEndpointWithId(), UUID.randomUUID().toString(), JsonObject.mapFrom(encumbrance).encodePrettily(), TRANSACTION_TENANT_HEADER).then().statusCode(404);
+    // cleanup
+    deleteTenant(TRANSACTION_TENANT_HEADER);
+  }
+
 
   private Ledger getLedgerAndValidate(String endpoint) throws MalformedURLException {
     return getData(endpoint, TRANSACTION_TENANT_HEADER).then()

--- a/src/test/java/org/folio/rest/impl/TransactionsSummariesTest.java
+++ b/src/test/java/org/folio/rest/impl/TransactionsSummariesTest.java
@@ -1,7 +1,13 @@
 package org.folio.rest.impl;
 
+import static javax.ws.rs.core.MediaType.APPLICATION_JSON;
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.MatcherAssert.assertThat;
+
 import java.net.MalformedURLException;
 
+import org.folio.rest.jaxrs.model.Error;
+import org.folio.rest.jaxrs.model.Errors;
 import org.folio.rest.jaxrs.model.OrderTransactionSummary;
 import org.junit.jupiter.api.Test;
 
@@ -9,17 +15,32 @@ import io.vertx.core.json.JsonObject;
 
 class TransactionsSummariesTest extends TestBase {
 
-  private static final String ORDER_TRANSACTION_SUMMARIES_ENDPOINT = "/finance-storage/order-transaction-summaries";
+  static final String ORDER_TRANSACTION_SUMMARIES_ENDPOINT = "/finance-storage/order-transaction-summaries";
   private static final String ORDER_TRANSACTION_SUMMARIES_ENDPOINT_WITH_ID = ORDER_TRANSACTION_SUMMARIES_ENDPOINT + "/{id}";
 
   @Test
   void testOrderTransactionSummaries() throws MalformedURLException {
     OrderTransactionSummary sample = new JsonObject(getFile("order_transaction_summary.sample")).mapTo(OrderTransactionSummary.class);
+    postData(ORDER_TRANSACTION_SUMMARIES_ENDPOINT, JsonObject.mapFrom(sample)
+      .encodePrettily(), TENANT_HEADER).as(OrderTransactionSummary.class);
+
     OrderTransactionSummary createdSummary = postData(ORDER_TRANSACTION_SUMMARIES_ENDPOINT, JsonObject.mapFrom(sample)
       .encodePrettily(), TENANT_HEADER).as(OrderTransactionSummary.class);
 
     testEntitySuccessfullyFetched(ORDER_TRANSACTION_SUMMARIES_ENDPOINT_WITH_ID, createdSummary.getId());
 
     deleteDataSuccess(ORDER_TRANSACTION_SUMMARIES_ENDPOINT_WITH_ID, createdSummary.getId());
+  }
+
+  @Test
+  void testOrderTransactionSummariesWithValidationError() throws MalformedURLException {
+    OrderTransactionSummary sample = new JsonObject(getFile("order_transaction_summary.sample")).mapTo(OrderTransactionSummary.class);
+    sample.setNumTransactions(0);
+    Error error = postData(ORDER_TRANSACTION_SUMMARIES_ENDPOINT, JsonObject.mapFrom(sample)
+      .encodePrettily(), TENANT_HEADER).then().statusCode(422).contentType(APPLICATION_JSON)
+        .extract().as(Errors.class).getErrors().get(0);
+
+   assertThat(error.getParameters().get(0).getKey(), equalTo("numTransactions"));
+    assertThat(error.getParameters().get(0).getValue(), equalTo("0"));
   }
 }


### PR DESCRIPTION
## Purpose
[MODFISTO-56](https://issues.folio.org/browse/MODFISTO-56) - We need to ensure that Either all transactions must be created(updated) or none of them before opening(closing) an order

## Approach
- updated post transaction summary API, on conflict id do nothing
- implemented (all or nothing approach)(https://wiki.folio.org/display/FOLIJET/Finance+Data+Model#FinanceDataModel-%22AllorNothing%22Operations) for POST and PUT encumbrance
- made POST idempotent for encumbrance type
- added unique index on set of fields for transactions with Encumbrance type
- added `fromFundId` and `encumbrance` fields presence check.
- RMB updated to 28.1.0

Additionally
- removed tags from sample data

#### TODOS and Open Questions
<!-- OPTIONAL
- [ ] Use GitHub checklists. When solved, check the box and explain the answer.
-->

## Pre-Merge Checklist
Before merging this PR, please go through the following list and take appropriate actions.

- Does this PR meet or exceed the expected quality standards?
  - [x] Code coverage on new code is 80% or greater
  - [x] Duplications on new code is 3% or less
  - [x] There are no major code smells or security issues
- Does this introduce breaking changes?
  - [ ] Were any API paths or methods changed, added or removed?
  - [ ] Were there any schema changes?
  - [ ] Did any of the interface versions change?
  - [ ] Were permissions changed, added, or removed?
  - [ ] Are there new interface dependencies?
  - [x] There are no breaking changes in this PR.
  
If there are breaking changes, please **STOP** and consider the following:

- What other modules will these changes impact?
- Do JIRAs exist to update the impacted modules?
  - [ ] If not, please create them
  - [ ] Do they contain the appropriate level of detail?  Which endpoints/schemas changed, etc.
  - [ ] Do they have all they appropriate links to blocked/related issues?
- Are the JIRAs under active development?  
  - [ ] If not, contact the project's PO and make sure they're aware of the urgency.
- Do PRs exist for these changes?
  - [ ] If so, have they been approved?

Ideally all of the PRs involved in breaking changes would be merged in the same day to avoid breaking the folio-testing environment.  Communication is paramount if that is to be achieved, especially as the number of intermodule and inter-team dependencies increase.  

While it's helpful for reviewers to help identify potential problems, ensuring that it's safe to merge is ultimately the responsibility of the PR assignee.
