### PR TITLE
MODFISTO-83 Migration script improvement to support transition of non-unique index to unique one

### DIFF
--- a/src/main/resources/templates/db_scripts/migration/budgets.sql
+++ b/src/main/resources/templates/db_scripts/migration/budgets.sql
@@ -50,5 +50,10 @@ UPDATE ${myuniversity}_${mymodule}.budget
 SET
   jsonb = jsonb - '{code}'::text[];
 
+-- Rename duplicates
+
+UPDATE ${myuniversity}_${mymodule}.budget
+SET jsonb = jsonb || jsonb_build_object('name', jsonb ->> 'name' || '_' || floor(random() * 2147483646 + 1)::int)
+WHERE jsonb ->> 'name' IN (SELECT jsonb->>'name' AS name FROM ${myuniversity}_${mymodule}.budget GROUP BY name HAVING COUNT(*) > 1);
 
 

--- a/src/main/resources/templates/db_scripts/schema.json
+++ b/src/main/resources/templates/db_scripts/schema.json
@@ -28,7 +28,7 @@
     {
       "run": "after",
       "snippetPath": "migration/budgets.sql",
-      "fromModuleVersion": "mod-finance-storage-4.0.0"
+      "fromModuleVersion": "mod-finance-storage-4.1.2"
     }
   ],
   "tables": [


### PR DESCRIPTION
## Purpose
[MODFISTO-83](https://issues.folio.org/browse/MODFISTO-83) need to improve migration script to rename duplicates when migrate from non-unique indexes to unique one for budget@name.

## Approach
- add suffix with random number (e.g. newBudgetName = oldName + randomNumber)

#### TODOS and Open Questions
- [ ] Perhaps it would be better to use a budget.id as a suffix instead of a random number?


## Learning
<!-- OPTIONAL
  Help out not only your reviewer, but also your fellow developer!
  Sometimes there are key pieces of information that you used to come up
  with your solution. Don't let all that hard work go to waste! A
  pull request is a *perfect opportunity to share the learning that
  you did. Add links to blog posts, patterns, libraries or addons used
  to solve this problem.
-->

## Pre-Merge Checklist
Before merging this PR, please go through the following list and take appropriate actions.

- Does this PR meet or exceed the expected quality standards?
  - [x] Code coverage on new code is 80% or greater
  - [x] Duplications on new code is 3% or less
  - [x] There are no major code smells or security issues
- Does this introduce breaking changes?
  - [ ] Were any API paths or methods changed, added or removed?
  - [ ] Were there any schema changes?
  - [ ] Did any of the interface versions change?
  - [ ] Were permissions changed, added, or removed?
  - [ ] Are there new interface dependencies?
  - [x] There are no breaking changes in this PR.
  
If there are breaking changes, please **STOP** and consider the following:

- What other modules will these changes impact?
- Do JIRAs exist to update the impacted modules?
  - [ ] If not, please create them
  - [ ] Do they contain the appropriate level of detail?  Which endpoints/schemas changed, etc.
  - [ ] Do they have all they appropriate links to blocked/related issues?
- Are the JIRAs under active development?  
  - [ ] If not, contact the project's PO and make sure they're aware of the urgency.
- Do PRs exist for these changes?
  - [ ] If so, have they been approved?

Ideally all of the PRs involved in breaking changes would be merged in the same day to avoid breaking the folio-testing environment.  Communication is paramount if that is to be achieved, especially as the number of intermodule and inter-team dependencies increase.  

While it's helpful for reviewers to help identify potential problems, ensuring that it's safe to merge is ultimately the responsibility of the PR assignee.
