### PR TITLE
MODFISTO-117 Index not being created during migration from FameFlower-Goldenrod

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -18,7 +18,7 @@
     <ramlfiles_path>${basedir}/ramls</ramlfiles_path>
     <ramlfiles_util_path>${ramlfiles_path}/raml-util</ramlfiles_util_path>
     <ramlfiles_acq_models_path>${ramlfiles_path}/acq-models</ramlfiles_acq_models_path>
-    <raml-module-builder.version>30.1.0</raml-module-builder.version>
+    <raml-module-builder.version>30.2.0</raml-module-builder.version>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <jmockit.version>1.48</jmockit.version>
     <vertx.version>3.9.1</vertx.version>

--- a/pom.xml
+++ b/pom.xml
@@ -18,7 +18,7 @@
     <ramlfiles_path>${basedir}/ramls</ramlfiles_path>
     <ramlfiles_util_path>${ramlfiles_path}/raml-util</ramlfiles_util_path>
     <ramlfiles_acq_models_path>${ramlfiles_path}/acq-models</ramlfiles_acq_models_path>
-    <raml-module-builder.version>30.0.2</raml-module-builder.version>
+    <raml-module-builder.version>30.1.0</raml-module-builder.version>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <jmockit.version>1.48</jmockit.version>
     <vertx.version>3.9.1</vertx.version>

--- a/src/main/resources/templates/db_scripts/schema.json
+++ b/src/main/resources/templates/db_scripts/schema.json
@@ -348,25 +348,26 @@
       ]
     },
     {
-      "tableName": "ledgerfy",
-      "fromModuleVersion": "mod-finance-storage-4.0.0",
+      "tableName": "ledgerFY",
+      "fromModuleVersion": "mod-finance-storage-5.0.1",
       "foreignKeys": [
         {
           "fieldName": "ledgerId",
           "targetTable": "ledger",
-          "tableAlias": "ledgerFy",
+          "tableAlias": "ledgerFY",
           "targetTableAlias": "ledger"
         },
         {
           "fieldName": "fiscalYearId",
           "targetTable": "fiscal_year",
-          "tableAlias": "ledgerFy",
+          "tableAlias": "ledgerFY",
           "targetTableAlias": "fiscalYear"
         }
       ],
       "uniqueIndex": [
         {
-          "fieldName": "ledgerId, fiscalYearId",
+          "fieldName": "ledgerId_fiscalYearId",
+          "multiFieldNames": "ledgerId, fiscalYearId",
           "tOps": "ADD"
         }
       ]


### PR DESCRIPTION
## Purpose
[MODFISTO-117](https://issues.folio.org/browse/MODFISTO-117)

## Approach
- revert ledgerFY table renaming
- update unique index definition for ledgerFY table
- upgrade to RMB 30.1.0


## Pre-Merge Checklist
Before merging this PR, please go through the following list and take appropriate actions.

- Does this PR meet or exceed the expected quality standards?
  - [x] Code coverage on new code is 80% or greater
  - [x] Duplications on new code is 3% or less
  - [x] There are no major code smells or security issues
- Does this introduce breaking changes?
  - [ ] Were any API paths or methods changed, added or removed?
  - [ ] Were there any schema changes?
  - [ ] Did any of the interface versions change?
  - [ ] Were permissions changed, added, or removed?
  - [ ] Are there new interface dependencies?
  - [x] There are no breaking changes in this PR.
  
If there are breaking changes, please **STOP** and consider the following:

- What other modules will these changes impact?
- Do JIRAs exist to update the impacted modules?
  - [ ] If not, please create them
  - [ ] Do they contain the appropriate level of detail?  Which endpoints/schemas changed, etc.
  - [ ] Do they have all they appropriate links to blocked/related issues?
- Are the JIRAs under active development?  
  - [ ] If not, contact the project's PO and make sure they're aware of the urgency.
- Do PRs exist for these changes?
  - [ ] If so, have they been approved?

Ideally all of the PRs involved in breaking changes would be merged in the same day to avoid breaking the folio-testing environment.  Communication is paramount if that is to be achieved, especially as the number of intermodule and inter-team dependencies increase.  

While it's helpful for reviewers to help identify potential problems, ensuring that it's safe to merge is ultimately the responsibility of the PR assignee.
