### PR TITLE
MODFISTO-196 Restrict rollover deletion for not completed rollover st…

### DIFF
--- a/src/main/java/org/folio/dao/rollover/RolloverErrorDAO.java
+++ b/src/main/java/org/folio/dao/rollover/RolloverErrorDAO.java
@@ -30,10 +30,10 @@ public class RolloverErrorDAO {
     return promise.future();
   }
 
-  public Future<Void> delete(String id, DBClient client) {
+  public Future<Void> deleteByQuery(Criterion filter, DBClient client) {
     Promise<Void> promise = Promise.promise();
     client.getPgClient()
-      .delete(LEDGER_FISCAL_YEAR_ROLLOVER_ERRORS_TABLE, id, reply -> {
+      .delete(LEDGER_FISCAL_YEAR_ROLLOVER_ERRORS_TABLE, filter, reply -> {
         if (reply.failed()) {
           handleFailure(promise, reply);
         } else {

--- a/src/main/java/org/folio/dao/rollover/RolloverErrorDAO.java
+++ b/src/main/java/org/folio/dao/rollover/RolloverErrorDAO.java
@@ -29,4 +29,17 @@ public class RolloverErrorDAO {
 
     return promise.future();
   }
+
+  public Future<Void> delete(String id, DBClient client) {
+    Promise<Void> promise = Promise.promise();
+    client.getPgClient()
+      .delete(LEDGER_FISCAL_YEAR_ROLLOVER_ERRORS_TABLE, id, reply -> {
+        if (reply.failed()) {
+          handleFailure(promise, reply);
+        } else {
+          promise.complete();
+        }
+      });
+    return promise.future();
+  }
 }

--- a/src/main/java/org/folio/service/rollover/RolloverProgressService.java
+++ b/src/main/java/org/folio/service/rollover/RolloverProgressService.java
@@ -1,13 +1,9 @@
 package org.folio.service.rollover;
 
-import io.vertx.core.CompositeFuture;
 import io.vertx.core.Future;
 import io.vertx.ext.web.handler.impl.HttpStatusException;
-import java.util.ArrayList;
-import java.util.List;
 import org.folio.dao.rollover.RolloverErrorDAO;
 import org.folio.dao.rollover.RolloverProgressDAO;
-import org.folio.rest.jaxrs.model.LedgerFiscalYearRolloverError;
 import org.folio.rest.jaxrs.model.LedgerFiscalYearRolloverProgress;
 import org.folio.rest.persist.Criteria.Criterion;
 import org.folio.rest.persist.CriterionBuilder;
@@ -44,12 +40,6 @@ public class RolloverProgressService {
       });
   }
 
-  public Future<List<LedgerFiscalYearRolloverError>> getLedgerRolloverErrorsForRollover(String rolloverId, DBClient client){
-    Criterion criterion = new CriterionBuilder()
-      .with("ledgerRolloverId", rolloverId).build();
-    return rolloverErrorDAO.get(criterion, client);
-  }
-
   public Future<Void> calculateAndUpdateFinancialProgressStatus(LedgerFiscalYearRolloverProgress progress, DBClient client) {
     Criterion criterion = new CriterionBuilder().with("ledgerRolloverId", progress.getLedgerRolloverId())
       .build();
@@ -83,11 +73,7 @@ public class RolloverProgressService {
   }
 
   public Future<Void> deleteRolloverErrors(String ledgerRolloverId, DBClient client) {
-    return getLedgerRolloverErrorsForRollover(ledgerRolloverId, client)
-      .compose(errors -> {
-        List<Future> futures = new ArrayList<>();
-        errors.forEach(error -> futures.add(rolloverErrorDAO.delete(error.getId(), client)));
-        return CompositeFuture.all(futures).mapEmpty();
-      });
+    Criterion criterion = new CriterionBuilder().with("ledgerRolloverId", ledgerRolloverId).build();
+    return rolloverErrorDAO.deleteByQuery(criterion, client);
   }
 }


### PR DESCRIPTION
## Purpose
[MODFISTO-196](https://issues.folio.org/browse/MODFISTO-196)
Restrict rollover deletion for not completed rollover status
## Approach
- Add cascade deletion for rollover errors
## Pre-Merge Checklist
Before merging this PR, please go through the following list and take appropriate actions.

- Does this PR meet or exceed the expected quality standards?
  - [ ] Code coverage on new code is 80% or greater
  - [ ] Duplications on new code is 3% or less
  - [ ] There are no major code smells or security issues
- Does this introduce breaking changes?
  - [ ] Were any API paths or methods changed, added or removed?
  - [ ] Were there any schema changes?
  - [ ] Did any of the interface versions change?
  - [ ] Were permissions changed, added, or removed?
  - [ ] Are there new interface dependencies?
  - [ ] There are no breaking changes in this PR.
  
If there are breaking changes, please **STOP** and consider the following:

- What other modules will these changes impact?
- Do JIRAs exist to update the impacted modules?
  - [ ] If not, please create them
  - [ ] Do they contain the appropriate level of detail?  Which endpoints/schemas changed, etc.
  - [ ] Do they have all they appropriate links to blocked/related issues?
- Are the JIRAs under active development?  
  - [ ] If not, contact the project's PO and make sure they're aware of the urgency.
- Do PRs exist for these changes?
  - [ ] If so, have they been approved?

Ideally all of the PRs involved in breaking changes would be merged in the same day to avoid breaking the folio-testing environment.  Communication is paramount if that is to be achieved, especially as the number of intermodule and inter-team dependencies increase.  

While it's helpful for reviewers to help identify potential problems, ensuring that it's safe to merge is ultimately the responsibility of the PR assignee.
