### PR TITLE
MODFISTO-210 Allow user to intentionally reset budget allowances duri…

### DIFF
--- a/src/main/resources/templates/db_scripts/budget_encumbrances_rollover.sql
+++ b/src/main/resources/templates/db_scripts/budget_encumbrances_rollover.sql
@@ -173,6 +173,8 @@ CREATE OR REPLACE FUNCTION ${myuniversity}_${mymodule}.build_budget(_budget json
         totalFunding                    decimal;
         available                       decimal;
         unavailable                     decimal;
+        allowableEncumbrance            decimal;
+        allowableExpenditure            decimal;
         metadata                        jsonb;
 
     BEGIN
@@ -198,6 +200,16 @@ CREATE OR REPLACE FUNCTION ${myuniversity}_${mymodule}.build_budget(_budget json
             newNetTransfers := available;
          ELSE
             newNetTransfers := 0;
+         END IF;
+
+         IF
+             (budget_rollover->>'setAllowances')::boolean
+         THEN
+             allowableEncumbrance := budget_rollover->>'allowableEncumbrance';
+             allowableExpenditure := budget_rollover->>'allowableExpenditure';
+         ELSE
+             allowableEncumbrance := _budget->>'allowableEncumbrance';
+             allowableExpenditure := _budget->>'allowableExpenditure';
          END IF;
 
         newAllocated := newAllocated +
@@ -226,8 +238,8 @@ CREATE OR REPLACE FUNCTION ${myuniversity}_${mymodule}.build_budget(_budget json
                 'allocationFrom', 0,
                 'metadata', metadata,
                 'budgetStatus', 'Active',
-                'allowableEncumbrance', budget_rollover->>'allowableEncumbrance',
-                'allowableExpenditure', budget_rollover->>'allowableExpenditure',
+                'allowableEncumbrance', allowableEncumbrance,
+                'allowableExpenditure', allowableExpenditure,
                 'netTransfers', newNetTransfers,
                 'awaitingPayment', 0,
                 'encumbered', 0,


### PR DESCRIPTION
## Purpose
[MODFISTO-210](https://issues.folio.org/browse/MODFISTO-210)
Allow user to intentionally reset budget allowances during rollover
## Approach
- Update sql script to populate allowable fields based on setAllowances
- Update acq-models
## Pre-Merge Checklist:
Before merging this PR, please go through the following list and take appropriate actions.

- Does this PR meet or exceed the expected quality standards?
  - [x] Code coverage on new code is 80% or greater
  - [x] Duplications on new code is 3% or less
  - [x] There are no major code smells or security issues
- Does this introduce breaking changes?
  - [ ] Were any API paths or methods changed, added or removed?
  - [ ] Were there any schema changes?
  - [ ] Did any of the interface versions change?
  - [ ] Were permissions changed, added, or removed?
  - [ ] Are there new interface dependencies?
  - [x] There are no breaking changes in this PR.
  
If there are breaking changes, please **STOP** and consider the following:

- What other modules will these changes impact?
- Do JIRAs exist to update the impacted modules?
  - [ ] If not, please create them
  - [ ] Do they contain the appropriate level of detail?  Which endpoints/schemas changed, etc.
  - [ ] Do they have all they appropriate links to blocked/related issues?
- Are the JIRAs under active development?  
  - [ ] If not, contact the project's PO and make sure they're aware of the urgency.
- Do PRs exist for these changes?
  - [ ] If so, have they been approved?

Ideally all of the PRs involved in breaking changes would be merged in the same day to avoid breaking the folio-testing environment.  Communication is paramount if that is to be achieved, especially as the number of intermodule and inter-team dependencies increase.  

While it's helpful for reviewers to help identify potential problems, ensuring that it's safe to merge is ultimately the responsibility of the PR assignee.
