### PR TITLE
[MODFISTO-219] - Allow user to delete a budget that has ONLY allocati…

### DIFF
--- a/src/main/java/org/folio/service/budget/BudgetService.java
+++ b/src/main/java/org/folio/service/budget/BudgetService.java
@@ -20,15 +20,13 @@ import javax.ws.rs.core.Response;
 
 import org.folio.dao.budget.BudgetDAO;
 import org.folio.rest.jaxrs.model.Budget;
-import org.folio.rest.jaxrs.model.BudgetCollection;
 import org.folio.rest.jaxrs.model.LedgerFiscalYearRollover;
 import org.folio.rest.jaxrs.model.Transaction;
-import org.folio.rest.persist.Criteria.Criteria;
 import org.folio.rest.persist.CriterionBuilder;
 import org.folio.rest.persist.DBClient;
 import org.folio.rest.persist.Criteria.Criterion;
-import org.folio.rest.persist.Criteria.Limit;
 import org.folio.rest.util.ErrorCodes;
+import org.folio.utils.CalculationUtils;
 
 import io.vertx.core.AsyncResult;
 import io.vertx.core.Context;
@@ -40,7 +38,6 @@ import io.vertx.core.logging.Logger;
 import io.vertx.core.logging.LoggerFactory;
 import io.vertx.ext.web.handler.impl.HttpStatusException;
 import io.vertx.sqlclient.Tuple;
-import org.folio.utils.CalculationUtils;
 
 public class BudgetService {
 

--- a/src/test/java/org/folio/rest/impl/BudgetTest.java
+++ b/src/test/java/org/folio/rest/impl/BudgetTest.java
@@ -57,7 +57,7 @@ public class BudgetTest extends TestBase {
   }
 
   @Test
-  void testDeleteBudgetWithExitingTransactionsMustFail() throws MalformedURLException {
+  void testAbleToDeleteBudgetWithExitingOnlyAllocationTransactions() throws MalformedURLException {
     prepareTenant(BUDGET_TENANT_HEADER, false, true);
 
     givenTestData(BUDGET_TENANT_HEADER,
@@ -68,8 +68,7 @@ public class BudgetTest extends TestBase {
       Pair.of(TRANSACTION, TRANSACTION.getPathToSampleFile()));
 
     deleteData(BUDGET.getEndpointWithId(), BUDGET.getId(), BUDGET_TENANT_HEADER).then()
-      .statusCode(400)
-      .body(containsString(TRANSACTION_IS_PRESENT_BUDGET_DELETE_ERROR));
+      .statusCode(204);
 
     deleteTenant(BUDGET_TENANT_HEADER);
   }


### PR DESCRIPTION
## Purpose
Allow user to delete a budget that has ONLY allocation type transactions
https://issues.folio.org/browse/MODFISTO-219

## Approach
Update query which block budget deletion

## Learning
<!-- OPTIONAL
  Help out not only your reviewer, but also your fellow developer!
  Sometimes there are key pieces of information that you used to come up
  with your solution. Don't let all that hard work go to waste! A
  pull request is a *perfect opportunity to share the learning that
  you did. Add links to blog posts, patterns, libraries or addons used
  to solve this problem.
-->

## Pre-Merge Checklist
Before merging this PR, please go through the following list and take appropriate actions.

- Does this PR meet or exceed the expected quality standards?
  - [x] Code coverage on new code is 80% or greater
  - [x] Duplications on new code is 3% or less
  - [x] There are no major code smells or security issues
- Does this introduce breaking changes?
  - [ ] Were any API paths or methods changed, added or removed?
  - [ ] Were there any schema changes?
  - [ ] Did any of the interface versions change?
  - [ ] Were permissions changed, added, or removed?
  - [ ] Are there new interface dependencies?
  - [x] There are no breaking changes in this PR.
  
If there are breaking changes, please **STOP** and consider the following:

- What other modules will these changes impact?
- Do JIRAs exist to update the impacted modules?
  - [ ] If not, please create them
  - [ ] Do they contain the appropriate level of detail?  Which endpoints/schemas changed, etc.
  - [ ] Do they have all they appropriate links to blocked/related issues?
- Are the JIRAs under active development?  
  - [ ] If not, contact the project's PO and make sure they're aware of the urgency.
- Do PRs exist for these changes?
  - [ ] If so, have they been approved?

Ideally all of the PRs involved in breaking changes would be merged in the same day to avoid breaking the folio-testing environment.  Communication is paramount if that is to be achieved, especially as the number of intermodule and inter-team dependencies increase.  

While it's helpful for reviewers to help identify potential problems, ensuring that it's safe to merge is ultimately the responsibility of the PR assignee.
