### PR TITLE
[MODFISTO-215] Avoid using uuid_generate_v4()

### DIFF
--- a/src/main/resources/templates/db_scripts/migration/pending_payment_cross_module.ftl
+++ b/src/main/resources/templates/db_scripts/migration/pending_payment_cross_module.ftl
@@ -7,7 +7,8 @@ WHERE jsonb ? 'numEncumbrances';
 
 -- Create pending payments from invoice lines
 INSERT INTO ${myuniversity}_${mymodule}.transaction
-SELECT public.uuid_generate_v4(), jsonb_strip_nulls(jsonb_build_object('transactionType', 'Pending payment', 'fromFundId', fd->>'fundId',
+SELECT public.uuid_generate_v5(public.uuid_nil(), concat('PPCM1', fdi.il->>'id', invoices.id, vouchers.id, budget.id, fy.id)),
+                                              jsonb_strip_nulls(jsonb_build_object('transactionType', 'Pending payment', 'fromFundId', fd->>'fundId',
                                               'amount', fdi.amount*(vouchers.jsonb->>'exchangeRate')::decimal, 'source', 'Invoice',
                                               'sourceInvoiceId', invoices.id, 'sourceInvoiceLineId', fdi.il->>'id',
                                               'fiscalYearId', budget.fiscalYearId, 'currency', fy.jsonb->>'currency',
@@ -29,7 +30,8 @@ WHERE invoices.jsonb->>'status' = 'Approved' AND budget.jsonb->>'budgetStatus'='
 
 -- Create pending payments not linked from invoices
 INSERT INTO ${myuniversity}_${mymodule}.transaction
-SELECT public.uuid_generate_v4(), jsonb_build_object('transactionType', 'Pending payment', 'fromFundId', fd->>'fundId',
+SELECT public.uuid_generate_v5(public.uuid_nil(), concat('PPCM2', fdi.invoice_id, budget.id, vouchers.id, fy.id)),
+                        jsonb_build_object('transactionType', 'Pending payment', 'fromFundId', fd->>'fundId',
 											  'amount', fdi.amount*(vouchers.jsonb->>'exchangeRate')::decimal, 'source', 'Invoice',
 											  'sourceInvoiceId', invoice_id,
 											  'fiscalYearId', budget.fiscalYearId, 'currency', fy.jsonb->>'currency')


### PR DESCRIPTION
## Purpose
[MODFISTO-215](https://issues.folio.org/browse/MODFISTO-215)

## Approach
See _Analysis_ in [MODFISTO-215](https://issues.folio.org/browse/MODFISTO-215).

#### TODOS and Open Questions
Is it possible to convert all Postgres scripts creating new records into Java ? It would be a cleaner way to resolve the constraint introduced by Pgpool-II, although it might lead to performance issues.

## Learning
With mod-finance-storage 4.2.2, the ledgerfy table is not updated when an invoice is created with a fiscal year that does not specify a currency. This leads to an error in the recalculate_totals() function. It happens when enabling the module with loadSample=true (this was needed to test pending_payment_cross_module.ftl).

## Pre-Merge Checklist
Before merging this PR, please go through the following list and take appropriate actions.

- Does this PR meet or exceed the expected quality standards?
  - [ ] Code coverage on new code is 80% or greater
  - [ ] Duplications on new code is 3% or less
  - [ ] There are no major code smells or security issues
- Does this introduce breaking changes?
  - [ ] Were any API paths or methods changed, added or removed?
  - [ ] Were there any schema changes?
  - [ ] Did any of the interface versions change?
  - [ ] Were permissions changed, added, or removed?
  - [ ] Are there new interface dependencies?
  - [ ] There are no breaking changes in this PR.
  
If there are breaking changes, please **STOP** and consider the following:

- What other modules will these changes impact?
- Do JIRAs exist to update the impacted modules?
  - [ ] If not, please create them
  - [ ] Do they contain the appropriate level of detail?  Which endpoints/schemas changed, etc.
  - [ ] Do they have all they appropriate links to blocked/related issues?
- Are the JIRAs under active development?  
  - [ ] If not, contact the project's PO and make sure they're aware of the urgency.
- Do PRs exist for these changes?
  - [ ] If so, have they been approved?

Ideally all of the PRs involved in breaking changes would be merged in the same day to avoid breaking the folio-testing environment.  Communication is paramount if that is to be achieved, especially as the number of intermodule and inter-team dependencies increase.  

While it's helpful for reviewers to help identify potential problems, ensuring that it's safe to merge is ultimately the responsibility of the PR assignee.
