### PR TITLE
[MODFISTO-293] Delete temp transactions after a failure

### DIFF
--- a/src/main/java/org/folio/dao/transactions/BaseTemporaryTransactionsDAO.java
+++ b/src/main/java/org/folio/dao/transactions/BaseTemporaryTransactionsDAO.java
@@ -92,6 +92,21 @@ public abstract class BaseTemporaryTransactionsDAO implements TemporaryTransacti
     return promise.future();
   }
 
+  public Future<Integer> deleteTempTransactionsWithNewConn(String summaryId, DBClient client) {
+    Promise<Integer> promise = Promise.promise();
+    Criterion criterion = getSummaryIdCriteria(summaryId);
+
+    client.getPgClient()
+      .delete(getTableName(), criterion, reply -> {
+        if (reply.failed()) {
+          handleFailure(promise, reply);
+        } else {
+          promise.complete(reply.result().rowCount());
+        }
+      });
+    return promise.future();
+  }
+
   public String getTableName() {
     return tableName;
   }

--- a/src/main/java/org/folio/dao/transactions/TemporaryTransactionDAO.java
+++ b/src/main/java/org/folio/dao/transactions/TemporaryTransactionDAO.java
@@ -12,5 +12,5 @@ public interface TemporaryTransactionDAO {
   Future<Transaction> createTempTransaction(Transaction transaction, String summaryId, DBClient client);
   Future<List<Transaction>> getTempTransactionsBySummaryId(String summaryId, DBClient client);
   Future<Integer> deleteTempTransactions(String summaryId, DBClient client);
-
+  Future<Integer> deleteTempTransactionsWithNewConn(String summaryId, DBClient client);
 }

--- a/src/main/java/org/folio/service/transactions/AllOrNothingTransactionService.java
+++ b/src/main/java/org/folio/service/transactions/AllOrNothingTransactionService.java
@@ -81,7 +81,7 @@ public class AllOrNothingTransactionService {
     return temporaryTransactionDAO.deleteTempTransactionsWithNewConn(summaryId, client)
                                   .compose(count -> Future.succeededFuture(null), t -> {
                                     log.error("Can't delete temporary transaction for {}", summaryId);
-                                    return Future.succeededFuture(null);
+                                    return Future.failedFuture(t);
                                   });
   }
 

--- a/src/main/java/org/folio/service/transactions/AllOrNothingTransactionService.java
+++ b/src/main/java/org/folio/service/transactions/AllOrNothingTransactionService.java
@@ -48,26 +48,39 @@ public class AllOrNothingTransactionService {
     this.transactionRestrictionService = transactionRestrictionService;
   }
 
-  public Future<Transaction> createTransaction(Transaction transaction, DBClient client, BiFunction<List<Transaction>, DBClient, Future<Void>> operation) {
-    try {
-      transactionRestrictionService.handleValidationError(transaction);
-    } catch (HttpException e) {
-      return  Future.failedFuture(e);
-    }
-
-    return transactionRestrictionService.verifyBudgetHasEnoughMoney(transaction, client)
+  public Future<Transaction> createTransaction(Transaction transaction, DBClient client, BiFunction<List<Transaction>,
+      DBClient, Future<Void>> operation) {
+    return validateTransactionAsFuture(transaction)
+      .compose(v -> transactionRestrictionService.verifyBudgetHasEnoughMoney(transaction, client))
       .compose(v -> processAllOrNothing(transaction, client, operation))
-      .map(transaction);
+      .map(transaction)
+      .recover(throwable -> cleanupTempTransactions(transaction, client)
+        .compose(v -> Future.failedFuture(throwable), v -> Future.failedFuture(throwable)));
   }
 
-  public Future<Void> updateTransaction(Transaction transaction, DBClient client, BiFunction<List<Transaction>, DBClient, Future<Void>> operation) {
+  public Future<Void> updateTransaction(Transaction transaction, DBClient client, BiFunction<List<Transaction>,
+      DBClient, Future<Void>> operation) {
+    return validateTransactionAsFuture(transaction)
+      .compose(v -> verifyTransactionExistence(transaction.getId(), client))
+      .compose(v -> processAllOrNothing(transaction, client, operation))
+      .recover(throwable -> cleanupTempTransactions(transaction, client)
+        .compose(v -> Future.failedFuture(throwable), v -> Future.failedFuture(throwable)));
+  }
+
+  private Future<Void> validateTransactionAsFuture(Transaction transaction) {
     try {
       transactionRestrictionService.handleValidationError(transaction);
+      return Future.succeededFuture();
     } catch (HttpException e) {
       return Future.failedFuture(e);
     }
-    return verifyTransactionExistence(transaction.getId(), client)
-      .compose(v -> processAllOrNothing(transaction, client, operation));
+  }
+
+  private Future<Void> cleanupTempTransactions(Transaction transaction, DBClient client) {
+    final String summaryId = transactionSummaryService.getSummaryId(transaction);
+    return client.startTx()
+      .compose(dbClient -> temporaryTransactionDAO.deleteTempTransactions(summaryId, client))
+      .compose(n -> client.endTx());
   }
 
   private Future<Void> processAllOrNothing(Transaction transaction, DBClient client, BiFunction<List<Transaction>, DBClient, Future<Void>> operation) {


### PR DESCRIPTION
## Purpose
[MODFISTO-293](https://issues.folio.org/browse/MODFISTO-293) - Error All expected transactions already processed
When a single transaction fails in a set of transactions with a summary, the summary will never be able to finish successfully, and typically the calling process will give up on the whole operation. So temporary transactions have to be removed, otherwise they will be taken into account the next time a user tries using a transaction summary on the same order/invoice.

We assume one thing: that a calling process will not try to fix a transaction after an error and continue creating or updating transactions for a given summary. There is nothing like that in FOLIO, and it would be surprising even from an API-using external program.

Eventually we should use unique summary ids, and this fix would be obsolete. It is meant for Lotus and possibly Kiwi.

## Approach
Catch any error (including validation) in createTransaction and updateTransaction, and remove all temporary transactions before returning it.

## Pre-Merge Checklist
Before merging this PR, please go through the following list and take appropriate actions.

- Does this PR meet or exceed the expected quality standards?
  - [x] Code coverage on new code is 80% or greater
  - [x] Duplications on new code is 3% or less
  - [x] There are no major code smells or security issues
- Does this introduce breaking changes?
  - [ ] Were any API paths or methods changed, added or removed?
  - [ ] Were there any schema changes?
  - [ ] Did any of the interface versions change?
  - [ ] Were permissions changed, added, or removed?
  - [ ] Are there new interface dependencies?
  - [x] There are no breaking changes in this PR.
  
If there are breaking changes, please **STOP** and consider the following:

- What other modules will these changes impact?
- Do JIRAs exist to update the impacted modules?
  - [ ] If not, please create them
  - [ ] Do they contain the appropriate level of detail?  Which endpoints/schemas changed, etc.
  - [ ] Do they have all they appropriate links to blocked/related issues?
- Are the JIRAs under active development?  
  - [ ] If not, contact the project's PO and make sure they're aware of the urgency.
- Do PRs exist for these changes?
  - [ ] If so, have they been approved?

Ideally all of the PRs involved in breaking changes would be merged in the same day to avoid breaking the folio-testing environment.  Communication is paramount if that is to be achieved, especially as the number of intermodule and inter-team dependencies increase.  

While it's helpful for reviewers to help identify potential problems, ensuring that it's safe to merge is ultimately the responsibility of the PR assignee.
