### PR TITLE
[MODFISTO-298] Support empty encumbrancesRollover array

### DIFF
--- a/src/main/java/org/folio/service/rollover/LedgerRolloverService.java
+++ b/src/main/java/org/folio/service/rollover/LedgerRolloverService.java
@@ -129,6 +129,10 @@ public class LedgerRolloverService {
   private Future<Void> startOrdersRollover(LedgerFiscalYearRollover rollover, LedgerFiscalYearRolloverProgress progress,
       RequestContext requestContext) {
     DBClient client = requestContext.toDBClient();
+    if (rollover.getEncumbrancesRollover().size() == 0) {
+      log.info("Orders rollover skipped for Ledger {}", rollover.getLedgerId());
+      return rolloverProgressService.calculateAndUpdateOverallProgressStatus(progress.withOrdersRolloverStatus(SUCCESS), client);
+    }
     log.info("Orders rollover started for Ledger {}", rollover.getLedgerId());
     return orderRolloverRestClient.postEmptyResponse(rollover, requestContext)
         .recover(t -> {

--- a/src/main/resources/templates/db_scripts/budget_encumbrances_rollover.sql
+++ b/src/main/resources/templates/db_scripts/budget_encumbrances_rollover.sql
@@ -59,6 +59,12 @@ CREATE OR REPLACE FUNCTION ${myuniversity}_${mymodule}.calculate_planned_encumbr
 			SELECT INTO encumbrance_rollover (er::jsonb) FROM jsonb_array_elements(_rollover_record->'encumbrancesRollover') er WHERE er->>'orderType'='One-time';
 		END IF;
 
+    IF
+      encumbrance_rollover IS NULL
+    THEN
+      RETURN 0.0;
+    END IF;
+
 		IF
 			encumbrance_rollover->>'basedOn'='Expended'
 		THEN

--- a/src/main/resources/templates/db_scripts/replace_null_amounts_by_zero.sql
+++ b/src/main/resources/templates/db_scripts/replace_null_amounts_by_zero.sql
@@ -1,0 +1,15 @@
+-- This script replaces null values by 0.0 for amount and initialAmountEncumbered in transactions and encumbered in budgets.
+-- Budgets' encumbered values might have to be fixed by hand afterwards.
+-- This is meant as a way to partially repair damage caused by MODFISTO-298, and should be executed manually.
+
+UPDATE ${myuniversity}_${mymodule}.transaction
+SET
+  jsonb = jsonb_set(jsonb || jsonb_build_object('amount', 0.0), '{encumbrance, initialAmountEncumbered}', '0.0')
+WHERE
+  jsonb->>'amount' IS NULL;
+
+UPDATE ${myuniversity}_${mymodule}.budget
+SET
+  jsonb = jsonb || jsonb_build_object('encumbered', 0.0)
+WHERE
+  jsonb->>'encumbered' IS NULL;


### PR DESCRIPTION
## Purpose
[MODFISTO-298](https://issues.folio.org/browse/MODFISTO-298) - Unable to access adjustment ledger

## Approach
- The rollover script is changed so that when there is no matching order type for the rollover, the encumbrance gets the value 0.0.
- The order rollover is skipped entirely when no order type has been selected (a success is reported - we don't have a "skipped" status).
- New script called replace_null_amounts_by_zero.sql that can be executed manually. Budget encumbered amounts should still be checked and fixed manually afterwards.


#### TODOS and Open Questions
[MODFISTO-299](https://issues.folio.org/browse/MODFISTO-299) - Order rollover errors are not reported

## Pre-Merge Checklist
Before merging this PR, please go through the following list and take appropriate actions.

- Does this PR meet or exceed the expected quality standards?
  - [ ] Code coverage on new code is 80% or greater
  - [ ] Duplications on new code is 3% or less
  - [ ] There are no major code smells or security issues
- Does this introduce breaking changes?
  - [ ] Were any API paths or methods changed, added or removed?
  - [ ] Were there any schema changes?
  - [ ] Did any of the interface versions change?
  - [ ] Were permissions changed, added, or removed?
  - [ ] Are there new interface dependencies?
  - [ ] There are no breaking changes in this PR.
  
If there are breaking changes, please **STOP** and consider the following:

- What other modules will these changes impact?
- Do JIRAs exist to update the impacted modules?
  - [ ] If not, please create them
  - [ ] Do they contain the appropriate level of detail?  Which endpoints/schemas changed, etc.
  - [ ] Do they have all they appropriate links to blocked/related issues?
- Are the JIRAs under active development?  
  - [ ] If not, contact the project's PO and make sure they're aware of the urgency.
- Do PRs exist for these changes?
  - [ ] If so, have they been approved?

Ideally all of the PRs involved in breaking changes would be merged in the same day to avoid breaking the folio-testing environment.  Communication is paramount if that is to be achieved, especially as the number of intermodule and inter-team dependencies increase.  

While it's helpful for reviewers to help identify potential problems, ensuring that it's safe to merge is ultimately the responsibility of the PR assignee.
