### PR TITLE
Module requires invoice-storage.invoices MODFISTO-343

### DIFF
--- a/descriptors/ModuleDescriptor-template.json
+++ b/descriptors/ModuleDescriptor-template.json
@@ -1,6 +1,12 @@
 {
   "id": "${artifactId}-${version}",
   "name": "Finance CRUD module",
+  "requires": [
+    {
+      "id" : "invoice-storage.invoices",
+      "version" : "5.0"
+    }
+  ],
   "provides": [
     {
       "id": "finance-storage.budgets",


### PR DESCRIPTION
This ensures that data for mod-invoice-storage + mod-orders-storage data is present during tenant init. Note that mod-invoice-storage also depends on mod-orders-storage.
