### PR TITLE
[MODFISTO-318] Fix scenario when new budgets not created during rollover process

### DIFF
--- a/src/main/java/org/folio/dao/rollover/RolloverBudgetDAO.java
+++ b/src/main/java/org/folio/dao/rollover/RolloverBudgetDAO.java
@@ -9,6 +9,7 @@ import org.folio.rest.persist.DBClient;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Objects;
 
 import static org.folio.rest.util.ResponseUtils.handleFailure;
 
@@ -38,9 +39,11 @@ public class RolloverBudgetDAO {
           handleFailure(promise, reply);
         } else {
           List<LedgerFiscalYearRolloverBudget> budgets = new ArrayList<>();
-          reply.result()
-            .spliterator()
-            .forEachRemaining(row -> budgets.add(row.get(JsonObject.class, 0).mapTo(LedgerFiscalYearRolloverBudget.class)));
+          if (Objects.nonNull(reply.result())) {
+            reply.result()
+              .spliterator()
+              .forEachRemaining(row -> budgets.add(row.get(JsonObject.class, 0).mapTo(LedgerFiscalYearRolloverBudget.class)));
+          }
           promise.complete(budgets);
         }
     });


### PR DESCRIPTION
## Purpose
https://issues.folio.org/browse/FAT-3002

## Approach
Karate test failed due to new logic connected with Preview functionality in case when rollover script not creating any new budgets during rollover process. 
This PR contains fix for the mentioned scenario

Screen from Karate:
![image](https://user-images.githubusercontent.com/25097693/191696892-7cac4677-4205-4929-9155-3f98cdd521c0.png)
