### PR TITLE
[MODFIN-256]. Define and implement Business API : Ledger Rollover Budgets [Part 2]

### DIFF
--- a/src/main/java/org/folio/dao/rollover/RolloverBudgetDAO.java
+++ b/src/main/java/org/folio/dao/rollover/RolloverBudgetDAO.java
@@ -39,7 +39,7 @@ public class RolloverBudgetDAO {
           handleFailure(promise, reply);
         } else {
           List<LedgerFiscalYearRolloverBudget> budgets = new ArrayList<>();
-          if (Objects.nonNull(reply.result())) {
+          if (Objects.nonNull(reply.result()) && reply.result().size() > 0) {
             reply.result()
               .spliterator()
               .forEachRemaining(row -> budgets.add(row.get(JsonObject.class, 0).mapTo(LedgerFiscalYearRolloverBudget.class)));

--- a/src/main/java/org/folio/dao/rollover/RolloverBudgetDAO.java
+++ b/src/main/java/org/folio/dao/rollover/RolloverBudgetDAO.java
@@ -39,7 +39,7 @@ public class RolloverBudgetDAO {
           handleFailure(promise, reply);
         } else {
           List<LedgerFiscalYearRolloverBudget> budgets = new ArrayList<>();
-          if (Objects.nonNull(reply.result()) && reply.result().size() > 0) {
+          if (Objects.nonNull(reply.result())) {
             reply.result()
               .spliterator()
               .forEachRemaining(row -> budgets.add(row.get(JsonObject.class, 0).mapTo(LedgerFiscalYearRolloverBudget.class)));

--- a/src/main/resources/templates/db_scripts/budget_encumbrances_rollover.sql
+++ b/src/main/resources/templates/db_scripts/budget_encumbrances_rollover.sql
@@ -432,10 +432,10 @@ $$ LANGUAGE plpgsql;
 CREATE OR REPLACE FUNCTION ${myuniversity}_${mymodule}.budget_encumbrances_rollover(_rollover_record jsonb) RETURNS VOID as $$
     DECLARE
             toFiscalYear					jsonb;
-            fromFiscalYear					jsonb;
-            temprow 						record;
-            exceptionText 					text;
-            exceptionDetails				text;
+            fromFiscalYear				jsonb;
+            temprow 						  record;
+            exceptionText 			  text;
+            exceptionDetails			text;
     BEGIN
 
 
@@ -456,23 +456,37 @@ CREATE OR REPLACE FUNCTION ${myuniversity}_${mymodule}.budget_encumbrances_rollo
 
         INSERT INTO ${myuniversity}_${mymodule}.ledger_fiscal_year_rollover_budget
             (
-                SELECT budget.id, budget.jsonb || jsonb_build_object(
+                SELECT id, budget || jsonb_build_object(
                     'ledgerRolloverId', _rollover_record->>'id',
                     'fundDetails', jsonb_build_object(
-                        'id', fund.id,
-                        'name', fund.jsonb->>'name',
-                        'code', fund.jsonb->>'code',
-                        'fundStatus', fund.jsonb->>'fundStatus',
-                        'fundTypeId', fund.jsonb->>'fundTypeId',
-                        'fundTypeName', fund_type.jsonb->>'name',
-                        'acqunitIds', fund.jsonb->>'acqUnitIds',
-                        'allocatedFromIds', fund.jsonb->>'allocatedFromIds',
-                        'allocatedToIds', fund.jsonb->>'allocatedToIds',
-                        'externalAccountNo', fund.jsonb->>'externalAccountNo',
-                        'description', fund.jsonb->>'description'))
-                FROM tmp_budget AS budget
-                LEFT JOIN ${myuniversity}_${mymodule}.fund AS fund ON fund.id = budget.fundId
-                LEFT JOIN ${myuniversity}_${mymodule}.fund_type AS fund_type ON fund.jsonb->>'fundTypeId' = fund_type.id::text
+                        'id', fund->'id',
+                        'name', fund->'name',
+                        'code', fund->'code',
+                        'fundStatus', fund->'fundStatus',
+                        'fundTypeId', fund->'fundTypeId',
+                        'fundTypeName', fund_type->'name',
+                        'acqUnitIds', fund->'acqUnitIds',
+                        'allocatedFromIds', fund->'allocatedFromIds',
+                        'allocatedFromNames', allocatedFromNames,
+                        'allocatedToIds', fund->'allocatedToIds',
+                        'allocatedToNames', allocatedToNames,
+                        'externalAccountNo', fund->'externalAccountNo',
+                        'description', fund->'description'))
+            FROM
+                (
+                    SELECT budget.id AS id, budget.jsonb AS budget, fund.jsonb AS fund, fund_type.jsonb AS fund_type,
+                    (
+                        SELECT json_agg(inner_fund.jsonb->>'name') FROM ${myuniversity}_${mymodule}.fund AS inner_fund
+                        WHERE (fund.jsonb->'allocatedFromIds')::jsonb ? inner_fund.id::text
+                    ) AS allocatedFromNames,
+                    (
+                        SELECT json_agg(inner_fund.jsonb->>'name') FROM ${myuniversity}_${mymodule}.fund AS inner_fund
+                        WHERE (fund.jsonb->'allocatedToIds')::jsonb ? inner_fund.id::text
+                    ) AS allocatedToNames
+                    FROM tmp_budget AS budget
+                    LEFT JOIN ${myuniversity}_${mymodule}.fund AS fund ON fund.id::text = budget.jsonb->>'fundId'
+                    LEFT JOIN ${myuniversity}_${mymodule}.fund_type AS fund_type ON fund_type.id::text = fund.jsonb->>'fundTypeId'
+                ) AS subquery
             );
 
         IF _rollover_record->>'rolloverType' <> 'Preview' THEN

--- a/src/main/resources/templates/db_scripts/budget_encumbrances_rollover.sql
+++ b/src/main/resources/templates/db_scripts/budget_encumbrances_rollover.sql
@@ -484,7 +484,7 @@ CREATE OR REPLACE FUNCTION ${myuniversity}_${mymodule}.budget_encumbrances_rollo
                         WHERE (fund.jsonb->'allocatedToIds')::jsonb ? inner_fund.id::text
                     ) AS allocatedToNames
                     FROM tmp_budget AS budget
-                    LEFT JOIN ${myuniversity}_${mymodule}.fund AS fund ON fund.id = budget.jsonb->'fundId'
+                    LEFT JOIN ${myuniversity}_${mymodule}.fund AS fund ON fund.id::text = budget.jsonb->>'fundId'
                     LEFT JOIN ${myuniversity}_${mymodule}.fund_type AS fund_type ON fund_type.id = fund.fundTypeId
                 ) AS subquery
             );

--- a/src/main/resources/templates/db_scripts/budget_encumbrances_rollover.sql
+++ b/src/main/resources/templates/db_scripts/budget_encumbrances_rollover.sql
@@ -468,7 +468,7 @@ CREATE OR REPLACE FUNCTION ${myuniversity}_${mymodule}.budget_encumbrances_rollo
                                 'acqunitIds', fund.jsonb->>'acqUnitIds',
                                 'allocatedFromIds', fund.jsonb->>'allocatedFromIds',
                                 'allocatedToIds', fund.jsonb->>'allocatedToIds',
-                                'externalAccountNo', fund.jsonb->>'externalAccountNo',
+                                'externalAccountNumberId', fund.jsonb->>'externalAccountNo',
                                 'description', fund.jsonb->>'description'))
                 FROM tmp_budget AS budget
                 LEFT JOIN ${myuniversity}_${mymodule}.fund AS fund ON fund.id = budget.fundId

--- a/src/main/resources/templates/db_scripts/budget_encumbrances_rollover.sql
+++ b/src/main/resources/templates/db_scripts/budget_encumbrances_rollover.sql
@@ -459,17 +459,17 @@ CREATE OR REPLACE FUNCTION ${myuniversity}_${mymodule}.budget_encumbrances_rollo
                 SELECT budget.id, budget.jsonb || jsonb_build_object(
                     'ledgerRolloverId', _rollover_record->>'id',
                     'fund', jsonb_build_object(
-                                'id', fund.id,
-                                'name', fund.jsonb->>'name',
-                                'code', fund.jsonb->>'code',
-                                'fundStatus', fund.jsonb->>'fundStatus',
-                                'fundTypeId', fund.jsonb->>'fundTypeId',
-                                'fundTypeName', fund_type.jsonb->>'name',
-                                'acqunitIds', fund.jsonb->>'acqUnitIds',
-                                'allocatedFromIds', fund.jsonb->>'allocatedFromIds',
-                                'allocatedToIds', fund.jsonb->>'allocatedToIds',
-                                'externalAccountNumberId', fund.jsonb->>'externalAccountNo',
-                                'description', fund.jsonb->>'description'))
+                        'id', fund.id,
+                        'name', fund.jsonb->>'name',
+                        'code', fund.jsonb->>'code',
+                        'fundStatus', fund.jsonb->>'fundStatus',
+                        'fundTypeId', fund.jsonb->>'fundTypeId',
+                        'fundTypeName', fund_type.jsonb->>'name',
+                        'acqunitIds', fund.jsonb->>'acqUnitIds',
+                        'allocatedFromIds', fund.jsonb->>'allocatedFromIds',
+                        'allocatedToIds', fund.jsonb->>'allocatedToIds',
+                        'externalAccountNumberId', fund.jsonb->>'externalAccountNo',
+                        'description', fund.jsonb->>'description'))
                 FROM tmp_budget AS budget
                 LEFT JOIN ${myuniversity}_${mymodule}.fund AS fund ON fund.id = budget.fundId
                 LEFT JOIN ${myuniversity}_${mymodule}.fund_type AS fund_type ON fund.jsonb->>'fundTypeId' = fund_type.id::text

--- a/src/main/resources/templates/db_scripts/budget_encumbrances_rollover.sql
+++ b/src/main/resources/templates/db_scripts/budget_encumbrances_rollover.sql
@@ -458,7 +458,7 @@ CREATE OR REPLACE FUNCTION ${myuniversity}_${mymodule}.budget_encumbrances_rollo
             (
                 SELECT budget.id, budget.jsonb || jsonb_build_object(
                     'ledgerRolloverId', _rollover_record->>'id',
-                    'fund', jsonb_build_object(
+                    'fundDetails', jsonb_build_object(
                         'id', fund.id,
                         'name', fund.jsonb->>'name',
                         'code', fund.jsonb->>'code',

--- a/src/main/resources/templates/db_scripts/budget_encumbrances_rollover.sql
+++ b/src/main/resources/templates/db_scripts/budget_encumbrances_rollover.sql
@@ -456,7 +456,23 @@ CREATE OR REPLACE FUNCTION ${myuniversity}_${mymodule}.budget_encumbrances_rollo
 
         INSERT INTO ${myuniversity}_${mymodule}.ledger_fiscal_year_rollover_budget
             (
-                SELECT id, jsonb || jsonb_build_object('ledgerRolloverId', _rollover_record->>'id') FROM tmp_budget
+                SELECT budget.id, budget.jsonb || jsonb_build_object(
+                    'ledgerRolloverId', _rollover_record->>'id',
+                    'fund', jsonb_build_object(
+                                'id', fund.id,
+                                'name', fund.jsonb->>'name',
+                                'code', fund.jsonb->>'code',
+                                'fundStatus', fund.jsonb->>'fundStatus',
+                                'fundTypeId', fund.jsonb->>'fundTypeId',
+                                'fundTypeName', fund_type.jsonb->>'name',
+                                'acqunitIds', fund.jsonb->>'acqUnitIds',
+                                'allocatedFromIds', fund.jsonb->>'allocatedFromIds',
+                                'allocatedToIds', fund.jsonb->>'allocatedToIds',
+                                'externalAccountNo', fund.jsonb->>'externalAccountNo',
+                                'description', fund.jsonb->>'description'))
+                FROM tmp_budget AS budget
+                LEFT JOIN ${myuniversity}_${mymodule}.fund AS fund ON fund.id = budget.fundId
+                LEFT JOIN ${myuniversity}_${mymodule}.fund_type AS fund_type ON fund.jsonb->>'fundTypeId' = fund_type.id::text
             );
 
         IF _rollover_record->>'rolloverType' <> 'Preview' THEN

--- a/src/main/resources/templates/db_scripts/budget_encumbrances_rollover.sql
+++ b/src/main/resources/templates/db_scripts/budget_encumbrances_rollover.sql
@@ -468,7 +468,7 @@ CREATE OR REPLACE FUNCTION ${myuniversity}_${mymodule}.budget_encumbrances_rollo
                         'acqunitIds', fund.jsonb->>'acqUnitIds',
                         'allocatedFromIds', fund.jsonb->>'allocatedFromIds',
                         'allocatedToIds', fund.jsonb->>'allocatedToIds',
-                        'externalAccountNumberId', fund.jsonb->>'externalAccountNo',
+                        'externalAccountNo', fund.jsonb->>'externalAccountNo',
                         'description', fund.jsonb->>'description'))
                 FROM tmp_budget AS budget
                 LEFT JOIN ${myuniversity}_${mymodule}.fund AS fund ON fund.id = budget.fundId


### PR DESCRIPTION
## Purpose
https://issues.folio.org/browse/MODFIN-256
https://issues.folio.org/browse/MODFISTO-318

## Approach
Update references to acq-models shcema to support:

- filtering rollover logs by ledger id

- provide fund details into rollover budgets response to reduce amount of UI calls

- provide expense class detatils into rollover budgets response that necessary in the final csv file

Update Rollover script to populate fund details in Rollover budgets API response (common Budgets API response not affected)

Corresponding Karate PR: https://github.com/folio-org/folio-integration-tests/pull/724/files

![All_Finance_Karate_tests](https://user-images.githubusercontent.com/25097693/193021868-c6951f5b-dc78-47f8-bc76-589a20d28d3c.png)
