### PR TITLE
[MODFIN-277]. Add support to filter by ledger for Rollover Logs API

### DIFF
--- a/src/main/resources/templates/db_scripts/ledger_rollover_log_view.sql
+++ b/src/main/resources/templates/db_scripts/ledger_rollover_log_view.sql
@@ -1,6 +1,7 @@
 CREATE OR REPLACE VIEW ${myuniversity}_${mymodule}.ledger_rollover_logs_view
 AS SELECT rollover.id AS id,
           jsonb_build_object('ledgerRolloverId', rollover.id) ||
+          jsonb_build_object('ledgerId', rollover.ledgerId) ||
           jsonb_build_object('startDate', progress.jsonb #>> '{metadata, createdDate}') ||
           CASE
               WHEN progress.jsonb ->> 'overallRolloverStatus' IN ('Not Started', 'In Progress') THEN '{}'::jsonb


### PR DESCRIPTION
## Purpose
https://issues.folio.org/browse/MODFIN-277

## Approach
Add ledgerId in Rollover Logs API response.
Corresponding schema has been changed in scope of commit: https://github.com/folio-org/acq-models/pull/399/commits/abd0b01876321d64e62e07a5d421f4d18de05dfe 
and updated reference in finance-storage to the latest acq models in previous PRs
 
![image](https://user-images.githubusercontent.com/25097693/193782817-9f6a38ae-1342-4df1-a489-151479e98b3b.png)
