### PR TITLE
[MODFISTO-355] "Encumbered" value is changed in repeatedly downloaded ".csv" file after the next test rollovers, "Encumbered (Exp Class)" value is doubled

### DIFF
--- a/src/main/resources/templates/db_scripts/budget_encumbrances_rollover.sql
+++ b/src/main/resources/templates/db_scripts/budget_encumbrances_rollover.sql
@@ -326,10 +326,10 @@ CREATE OR REPLACE FUNCTION ${myuniversity}_${mymodule}.rollover_order(_order_id 
         ELSE
             EXECUTE format(update_budget_amounts_query, 'budget', _rollover_record, _order_id);
             EXECUTE format(update_budget_amounts_query, 'ledger_fiscal_year_rollover_budget', _rollover_record, _order_id);
-        END IF;
 
-        INSERT INTO tmp_encumbered_transactions SELECT * FROM tmp_transaction
-        ON CONFLICT DO NOTHING;
+            INSERT INTO tmp_encumbered_transactions SELECT * FROM tmp_transaction
+            ON CONFLICT DO NOTHING;
+        END IF;
 
         DROP TABLE IF EXISTS tmp_transaction;
     END;

--- a/src/main/resources/templates/db_scripts/schema.json
+++ b/src/main/resources/templates/db_scripts/schema.json
@@ -69,7 +69,7 @@
     {
       "run": "after",
       "snippetPath": "budget_encumbrances_rollover.sql",
-      "fromModuleVersion": "mod-finance-storage-8.3.0"
+      "fromModuleVersion": "mod-finance-storage-8.3.1"
     },
     {
       "run": "after",


### PR DESCRIPTION
## Purpose
Bug was observed when repeatedly run test rollover with another "Based on" option for the same ledger and fiscal year. The last encumbrance value of the budget was applied to all budgets from ledger_fiscal_year_rollover_budget table which have same ledger and fiscal year

## Approach

- Was added the check to ledgerId which will ensure that other data from the ledger_fiscal_year_rollover_budget table are not overwritten

## Learning
[MODFISTO-355](https://issues.folio.org/browse/MODFISTO-355)

## Pre-Merge Checklist
Before merging this PR, please go through the following list and take appropriate actions.

- Does this PR meet or exceed the expected quality standards?
  - [ ] Code coverage on new code is 80% or greater
  - [ ] Duplications on new code is 3% or less
  - [ ] There are no major code smells or security issues
- Does this introduce breaking changes?
  - [ ] Were any API paths or methods changed, added or removed?
  - [ ] Were there any schema changes?
  - [ ] Did any of the interface versions change?
  - [ ] Were permissions changed, added, or removed?
  - [ ] Are there new interface dependencies?
  - [ ] There are no breaking changes in this PR.
  
If there are breaking changes, please **STOP** and consider the following:

- What other modules will these changes impact?
- Do JIRAs exist to update the impacted modules?
  - [ ] If not, please create them
  - [ ] Do they contain the appropriate level of detail?  Which endpoints/schemas changed, etc.
  - [ ] Do they have all they appropriate links to blocked/related issues?
- Are the JIRAs under active development?  
  - [ ] If not, contact the project's PO and make sure they're aware of the urgency.
- Do PRs exist for these changes?
  - [ ] If so, have they been approved?

Ideally all of the PRs involved in breaking changes would be merged in the same day to avoid breaking the folio-testing environment.  Communication is paramount if that is to be achieved, especially as the number of intermodule and inter-team dependencies increase.  

While it's helpful for reviewers to help identify potential problems, ensuring that it's safe to merge is ultimately the responsibility of the PR assignee.
