### PR TITLE
[MODFISTO-362] Expense class code and status are not shown in test rollover results .csv file

### DIFF
--- a/src/main/java/org/folio/dao/budget/BudgetExpenseClassDAOImpl.java
+++ b/src/main/java/org/folio/dao/budget/BudgetExpenseClassDAOImpl.java
@@ -17,7 +17,7 @@ public class BudgetExpenseClassDAOImpl implements BudgetExpenseClassDAO{
 
   private static final String SELECT_BUDGET_EXPENSE_CLASSES_BY_BUDGET_ID = "SELECT budget_expense_class.jsonb "
     + "FROM %s AS budget_expense_class "
-    + "WHERE budget_expense_class.budgetid = $1";
+    + "WHERE budget_expense_class.jsonb->>'budgetId' = $1";
 
   public Future<List<BudgetExpenseClass>> getTemporaryBudgetExpenseClasses(String budgetId, DBClient client) {
     Promise<List<BudgetExpenseClass>> promise = Promise.promise();

--- a/src/main/java/org/folio/service/budget/RolloverBudgetExpenseClassTotalsService.java
+++ b/src/main/java/org/folio/service/budget/RolloverBudgetExpenseClassTotalsService.java
@@ -96,6 +96,7 @@ public class RolloverBudgetExpenseClassTotalsService {
     return new BudgetExpenseClassTotal()
       .withId(expenseClass.getId())
       .withExpenseClassName(expenseClass.getName())
+      .withExpenseClassCode(expenseClass.getCode())
       .withEncumbered(encumbered)
       .withAwaitingPayment(awaitingPayment)
       .withExpended(expended)


### PR DESCRIPTION
## Purpose
After financial rollover some fields(expense class code, expense class status) didn't show in rollover logs

## Learning
[MODFISTO-362](https://issues.folio.org/browse/MODFISTO-362)

## Pre-Merge Checklist
Before merging this PR, please go through the following list and take appropriate actions.

- Does this PR meet or exceed the expected quality standards?
  - [ ] Code coverage on new code is 80% or greater
  - [ ] Duplications on new code is 3% or less
  - [ ] There are no major code smells or security issues
- Does this introduce breaking changes?
  - [ ] Were any API paths or methods changed, added or removed?
  - [ ] Were there any schema changes?
  - [ ] Did any of the interface versions change?
  - [ ] Were permissions changed, added, or removed?
  - [ ] Are there new interface dependencies?
  - [ ] There are no breaking changes in this PR.
  
If there are breaking changes, please **STOP** and consider the following:

- What other modules will these changes impact?
- Do JIRAs exist to update the impacted modules?
  - [ ] If not, please create them
  - [ ] Do they contain the appropriate level of detail?  Which endpoints/schemas changed, etc.
  - [ ] Do they have all they appropriate links to blocked/related issues?
- Are the JIRAs under active development?  
  - [ ] If not, contact the project's PO and make sure they're aware of the urgency.
- Do PRs exist for these changes?
  - [ ] If so, have they been approved?

Ideally all of the PRs involved in breaking changes would be merged in the same day to avoid breaking the folio-testing environment.  Communication is paramount if that is to be achieved, especially as the number of intermodule and inter-team dependencies increase.  

While it's helpful for reviewers to help identify potential problems, ensuring that it's safe to merge is ultimately the responsibility of the PR assignee.
