### PR TITLE
[MODFISTO-367] Do not rely on totalRecords

### DIFF
--- a/scripts/fix_lotus_encumbrances/fix_lotus_encumbrances.py
+++ b/scripts/fix_lotus_encumbrances/fix_lotus_encumbrances.py
@@ -124,9 +124,7 @@ def get_fiscal_year_ids_by_query(query):
 def get_by_chunks(url, query, key):
     records = []
     offset = 0
-    first = True
-    total_records = 1
-    while first or len(records) < total_records:
+    while True:
         params = {'query': query, 'offset': offset, 'limit': MAX_BY_CHUNK}
         r = requests.get(url, headers=headers, params=params)
         if r.status_code != 200:
@@ -135,12 +133,9 @@ def get_by_chunks(url, query, key):
         if key not in j.keys():
             raise Exception(f'Could not find key when retrieving by chunks; url={url}, key={key}')
         records_in_chunk = j[key]
-        if not first and len(records_in_chunk) == 0:
-            raise Exception(f'Error retrieving by chunk: no record; url={url}, offset={offset}')
+        if len(records_in_chunk) == 0:
+            break
         records.extend(records_in_chunk)
-        if first:
-            total_records = j['totalRecords']
-            first = False
         offset += len(records_in_chunk)
     return records
 


### PR DESCRIPTION
## Purpose
[MODFISTO-367](https://issues.folio.org/browse/MODFISTO-367) - Encumbrance script: avoid requesting too many orders at once

## Approach
Fixed `get_by_chunks()` as it would fail for large amounts of orders. `totalRecords` is not always accurate so it's better to not rely on it.

## Pre-Merge Checklist:
Before merging this PR, please go through the following list and take appropriate actions.

- Does this PR meet or exceed the expected quality standards?
  - [ ] Code coverage on new code is 80% or greater
  - [ ] Duplications on new code is 3% or less
  - [ ] There are no major code smells or security issues
- Does this introduce breaking changes?
  - [ ] Were any API paths or methods changed, added or removed?
  - [ ] Were there any schema changes?
  - [ ] Did any of the interface versions change?
  - [ ] Were permissions changed, added or removed?
  - [ ] Are there new interface dependencies?
  - [ ] There are no breaking changes in this PR.

If there are breaking changes, please **STOP** and consider the following:

- What other modules will these changes impact?
- Do JIRAs exist to update the impacted modules?
  - [ ] If not, please create them
  - [ ] Do they contain the appropriate level of detail?  Which endpoints/schemas changed, etc.
  - [ ] Do they have all the appropriate links to blocked/related issues?
- Are the JIRAs under active development?
  - [ ] If not, contact the project's PO and make sure they're aware of the urgency.
- Do PRs exist for these changes?
  - [ ] If so, have they been approved?
- Did you modify code to call some additional endpoints?
  - [ ] If so, do you check that necessary module permission added in ModuleDescriptor-template.yaml file?

Ideally, all the PRs involved in breaking changes would be merged on the same day
to avoid breaking the folio-testing environment.
Communication is paramount if that is to be achieved,
especially as the number of inter-module and inter-team dependencies increase.

While it's helpful for reviewers to help identify potential problems,
ensuring that it's safe to merge is ultimately the responsibility of the PR assignee.
