### PR TITLE
[MODFISTO-377]. Replace Vertx shared lock with DB lock to increase stability working with transactions

### DIFF
--- a/src/main/java/org/folio/dao/summary/BaseTransactionSummaryDAO.java
+++ b/src/main/java/org/folio/dao/summary/BaseTransactionSummaryDAO.java
@@ -1,5 +1,7 @@
 package org.folio.dao.summary;
 
+import io.vertx.core.AsyncResult;
+import org.folio.rest.persist.Conn;
 import static org.folio.rest.persist.HelperUtils.ID_FIELD_NAME;
 import static org.folio.rest.util.ResponseUtils.handleFailure;
 import static org.folio.service.transactions.AllOrNothingTransactionService.TRANSACTION_SUMMARY_NOT_FOUND_FOR_TRANSACTION;
@@ -25,23 +27,31 @@ public abstract class BaseTransactionSummaryDAO implements TransactionSummaryDao
   @Override
   public Future<JsonObject> getSummaryById(String summaryId, DBClient client) {
     Promise<JsonObject> promise = Promise.promise();
-
-    logger.debug("Get summary={}", summaryId);
-    client.getPgClient().getById(getTableName(), summaryId, reply -> {
-      if (reply.failed()) {
-        logger.error("Summary retrieval with id={} failed", summaryId, reply.cause());
-        handleFailure(promise, reply);
-      } else {
-        final JsonObject summary = reply.result();
-        if (summary == null) {
-          promise.fail(new HttpException(Response.Status.BAD_REQUEST.getStatusCode(), TRANSACTION_SUMMARY_NOT_FOUND_FOR_TRANSACTION));
-        } else {
-          logger.debug("Summary with id={} successfully extracted", summaryId);
-          promise.complete(summary);
-        }
-      }
-    });
+    client.getPgClient().getById(getTableName(), summaryId, reply -> processGetResult(summaryId, promise, reply));
     return promise.future();
+  }
+
+  @Override
+  public Future<JsonObject> getSummaryByIdWithLocking(String summaryId, Conn conn) {
+    Promise<JsonObject> promise = Promise.promise();
+    conn.getByIdForUpdate(getTableName(), summaryId).onComplete(reply -> processGetResult(summaryId, promise, reply));
+    return promise.future();
+  }
+
+  private void processGetResult(String summaryId, Promise<JsonObject> promise, AsyncResult<JsonObject> reply) {
+    if (reply.failed()) {
+      logger.error("Summary retrieval with id={} failed", summaryId, reply.cause());
+      handleFailure(promise, reply);
+    } else {
+      final JsonObject summary = reply.result();
+
+      if (summary == null) {
+        promise.fail(new HttpException(Response.Status.BAD_REQUEST.getStatusCode(), TRANSACTION_SUMMARY_NOT_FOUND_FOR_TRANSACTION));
+      } else {
+        logger.debug("Summary with id={} successfully extracted", summaryId);
+        promise.complete(summary);
+      }
+    }
   }
 
   @Override

--- a/src/main/java/org/folio/dao/summary/BaseTransactionSummaryDAO.java
+++ b/src/main/java/org/folio/dao/summary/BaseTransactionSummaryDAO.java
@@ -20,8 +20,6 @@ import io.vertx.core.Future;
 import io.vertx.core.Promise;
 import io.vertx.core.json.JsonObject;
 
-import java.util.Objects;
-
 public abstract class BaseTransactionSummaryDAO implements TransactionSummaryDao {
   protected final Logger logger = LogManager.getLogger(this.getClass());
 
@@ -45,7 +43,7 @@ public abstract class BaseTransactionSummaryDAO implements TransactionSummaryDao
     } else {
       final JsonObject summary = reply.result();
 
-      if (Objects.isNull(summary)) {
+      if (summary == null) {
         return Future.failedFuture(new HttpException(Response.Status.BAD_REQUEST.getStatusCode(), TRANSACTION_SUMMARY_NOT_FOUND_FOR_TRANSACTION));
       } else {
         logger.debug("Summary with id={} successfully extracted", summaryId);

--- a/src/main/java/org/folio/dao/summary/TransactionSummaryDao.java
+++ b/src/main/java/org/folio/dao/summary/TransactionSummaryDao.java
@@ -1,6 +1,7 @@
 package org.folio.dao.summary;
 
 import io.vertx.core.json.JsonObject;
+import org.folio.rest.persist.Conn;
 import org.folio.rest.persist.DBClient;
 
 import io.vertx.core.Future;
@@ -8,6 +9,8 @@ import io.vertx.core.Future;
 public interface TransactionSummaryDao {
 
   Future<JsonObject> getSummaryById(String summaryId, DBClient client);
+
+  Future<JsonObject> getSummaryByIdWithLocking(String summaryId, Conn conn);
 
   Future<Void> updateSummaryInTransaction(JsonObject summary, DBClient client);
 }

--- a/src/main/java/org/folio/dao/transactions/BaseTemporaryTransactionsDAO.java
+++ b/src/main/java/org/folio/dao/transactions/BaseTemporaryTransactionsDAO.java
@@ -4,7 +4,6 @@ import static org.folio.rest.persist.PostgresClient.pojo2JsonObject;
 import static org.folio.rest.util.ResponseUtils.handleFailure;
 
 import java.util.List;
-import java.util.Objects;
 import java.util.UUID;
 
 import javax.ws.rs.core.Response;
@@ -33,7 +32,7 @@ public abstract class BaseTemporaryTransactionsDAO implements TemporaryTransacti
 
   @Override
   public Future<Transaction> createTempTransaction(Transaction transaction, String summaryId, String tenantId, Conn conn) {
-    if (Objects.isNull(transaction.getId())) {
+    if (transaction.getId() == null) {
       transaction.setId(UUID.randomUUID().toString());
     }
 

--- a/src/main/java/org/folio/dao/transactions/TemporaryEncumbranceTransactionDAO.java
+++ b/src/main/java/org/folio/dao/transactions/TemporaryEncumbranceTransactionDAO.java
@@ -5,13 +5,13 @@ import io.vertx.core.json.JsonObject;
 import org.folio.rest.jaxrs.model.Transaction;
 import org.folio.rest.persist.Conn;
 import org.folio.rest.persist.Criteria.Criterion;
+import org.folio.rest.util.ResponseUtils;
 
 import java.util.ArrayList;
 import java.util.List;
 
 import static java.lang.String.format;
 import static org.apache.commons.lang3.StringUtils.EMPTY;
-import static org.folio.rest.util.ResponseUtils.handleFailure;
 
 public class TemporaryEncumbranceTransactionDAO extends BaseTemporaryTransactionsDAO{
 
@@ -35,16 +35,13 @@ public class TemporaryEncumbranceTransactionDAO extends BaseTemporaryTransaction
   @Override
   public Future<List<Transaction>> getTempTransactions(Criterion criterion, Conn conn) {
     return conn.execute(format(TEMPORARY_ENCUMBRANCE_TRANSACTIONS_QUERY, criterion.getWhere()))
-      .transform(reply -> {
-        if (reply.failed()) {
-          return Future.future(promise -> handleFailure(promise, reply));
-        } else {
-          List<Transaction> transactions = new ArrayList<>();
-          reply.result().spliterator()
-            .forEachRemaining(row -> transactions.add(row.get(JsonObject.class, 0).mapTo(Transaction.class)));
-          return Future.succeededFuture(transactions);
-        }
-      });
+      .map(result -> {
+        List<Transaction> transactions = new ArrayList<>();
+        result.spliterator()
+          .forEachRemaining(row -> transactions.add(row.get(JsonObject.class, 0).mapTo(Transaction.class)));
+        return transactions;
+      })
+      .recover(ResponseUtils::handleFailure);
   }
 
 }

--- a/src/main/java/org/folio/dao/transactions/TemporaryEncumbranceTransactionDAO.java
+++ b/src/main/java/org/folio/dao/transactions/TemporaryEncumbranceTransactionDAO.java
@@ -1,18 +1,22 @@
 package org.folio.dao.transactions;
 
 import io.vertx.core.Future;
+import io.vertx.core.json.JsonObject;
 import org.folio.rest.jaxrs.model.Transaction;
 import org.folio.rest.persist.Conn;
 import org.folio.rest.persist.Criteria.Criterion;
 
+import java.util.ArrayList;
 import java.util.List;
 
+import static java.lang.String.format;
 import static org.apache.commons.lang3.StringUtils.EMPTY;
 import static org.folio.rest.util.ResponseUtils.handleFailure;
 
 public class TemporaryEncumbranceTransactionDAO extends BaseTemporaryTransactionsDAO{
 
   public static final String TEMPORARY_ENCUMBRANCE_TRANSACTIONS_TABLE = "tmp_encumbered_transactions";
+  private static final String TEMPORARY_ENCUMBRANCE_TRANSACTIONS_QUERY = "SELECT jsonb FROM tmp_encumbered_transactions WHERE %s ";
 
   public TemporaryEncumbranceTransactionDAO() {
     super(TEMPORARY_ENCUMBRANCE_TRANSACTIONS_TABLE);
@@ -30,9 +34,17 @@ public class TemporaryEncumbranceTransactionDAO extends BaseTemporaryTransaction
 
   @Override
   public Future<List<Transaction>> getTempTransactions(Criterion criterion, Conn conn) {
-    return conn.get(TEMPORARY_ENCUMBRANCE_TRANSACTIONS_TABLE, Transaction.class, criterion)
-      .transform(reply -> reply.failed() ? Future.future(promise -> handleFailure(promise, reply))
-        : Future.succeededFuture(reply.result().getResults()));
+    return conn.execute(format(TEMPORARY_ENCUMBRANCE_TRANSACTIONS_QUERY, criterion.getWhere()))
+      .transform(reply -> {
+        if (reply.failed()) {
+          return Future.future(promise -> handleFailure(promise, reply));
+        } else {
+          List<Transaction> transactions = new ArrayList<>();
+          reply.result().spliterator()
+            .forEachRemaining(row -> transactions.add(row.get(JsonObject.class, 0).mapTo(Transaction.class)));
+          return Future.succeededFuture(transactions);
+        }
+      });
   }
 
 }

--- a/src/main/java/org/folio/dao/transactions/TemporaryEncumbranceTransactionDAO.java
+++ b/src/main/java/org/folio/dao/transactions/TemporaryEncumbranceTransactionDAO.java
@@ -1,23 +1,18 @@
 package org.folio.dao.transactions;
 
 import io.vertx.core.Future;
-import io.vertx.core.Promise;
-import io.vertx.core.json.JsonObject;
 import org.folio.rest.jaxrs.model.Transaction;
+import org.folio.rest.persist.Conn;
 import org.folio.rest.persist.Criteria.Criterion;
-import org.folio.rest.persist.DBClient;
 
-import java.util.ArrayList;
 import java.util.List;
 
-import static java.lang.String.format;
 import static org.apache.commons.lang3.StringUtils.EMPTY;
 import static org.folio.rest.util.ResponseUtils.handleFailure;
 
 public class TemporaryEncumbranceTransactionDAO extends BaseTemporaryTransactionsDAO{
 
   public static final String TEMPORARY_ENCUMBRANCE_TRANSACTIONS_TABLE = "tmp_encumbered_transactions";
-  private static final String TEMPORARY_ENCUMBRANCE_TRANSACTIONS_QUERY = "SELECT jsonb FROM tmp_encumbered_transactions WHERE %s ";
 
   public TemporaryEncumbranceTransactionDAO() {
     super(TEMPORARY_ENCUMBRANCE_TRANSACTIONS_TABLE);
@@ -34,20 +29,10 @@ public class TemporaryEncumbranceTransactionDAO extends BaseTemporaryTransaction
   }
 
   @Override
-  public Future<List<Transaction>> getTempTransactions(Criterion criterion, DBClient client) {
-    Promise<List<Transaction>> promise = Promise.promise();
-    client.getPgClient()
-      .select(format(TEMPORARY_ENCUMBRANCE_TRANSACTIONS_QUERY, criterion.getWhere()), reply -> {
-        if (reply.failed()) {
-          handleFailure(promise, reply);
-        } else {
-          List<Transaction> transactions = new ArrayList<>();
-          reply.result().spliterator()
-            .forEachRemaining(row -> transactions.add(row.get(JsonObject.class, 0).mapTo(Transaction.class)));
-          promise.complete(transactions);
-        }
-      });
-    return promise.future();
+  public Future<List<Transaction>> getTempTransactions(Criterion criterion, Conn conn) {
+    return conn.get(TEMPORARY_ENCUMBRANCE_TRANSACTIONS_TABLE, Transaction.class, criterion)
+      .transform(reply -> reply.failed() ? Future.future(promise -> handleFailure(promise, reply))
+        : Future.succeededFuture(reply.result().getResults()));
   }
 
 }

--- a/src/main/java/org/folio/dao/transactions/TemporaryTransactionDAO.java
+++ b/src/main/java/org/folio/dao/transactions/TemporaryTransactionDAO.java
@@ -3,6 +3,7 @@ package org.folio.dao.transactions;
 import java.util.List;
 
 import org.folio.rest.jaxrs.model.Transaction;
+import org.folio.rest.persist.Conn;
 import org.folio.rest.persist.Criteria.Criterion;
 import org.folio.rest.persist.DBClient;
 
@@ -10,9 +11,9 @@ import io.vertx.core.Future;
 
 public interface TemporaryTransactionDAO {
 
-  Future<Transaction> createTempTransaction(Transaction transaction, String summaryId, DBClient client);
-  Future<List<Transaction>> getTempTransactions(Criterion criterion, DBClient client);
-  Future<List<Transaction>> getTempTransactionsBySummaryId(String summaryId, DBClient client);
+  Future<Transaction> createTempTransaction(Transaction transaction, String summaryId, String tenantId, Conn conn);
+  Future<List<Transaction>> getTempTransactions(Criterion criterion, Conn conn);
+  Future<List<Transaction>> getTempTransactionsBySummaryId(String summaryId, Conn conn);
   Future<Integer> deleteTempTransactions(String summaryId, DBClient client);
   Future<Integer> deleteTempTransactionsWithNewConn(String summaryId, DBClient client);
 }

--- a/src/main/java/org/folio/service/summary/AbstractTransactionSummaryService.java
+++ b/src/main/java/org/folio/service/summary/AbstractTransactionSummaryService.java
@@ -1,5 +1,6 @@
 package org.folio.service.summary;
 
+import org.folio.rest.persist.Conn;
 import static org.folio.service.transactions.AllOrNothingTransactionService.ALL_EXPECTED_TRANSACTIONS_ALREADY_PROCESSED;
 
 import javax.ws.rs.core.Response;
@@ -27,7 +28,8 @@ public abstract class AbstractTransactionSummaryService implements TransactionSu
 
   @Override
   public Future<JsonObject> getAndCheckTransactionSummary(Transaction transaction, DBClient client) {
-    return this.getTransactionSummary(transaction, client)
+    String summaryId = getSummaryId(transaction);
+    return this.getTransactionSummary(summaryId, client)
       .map(summary -> {
         if ((isProcessed(summary))) {
           logger.debug("Expected number of transactions for summary with id={} already processed", summary.getString(HelperUtils.ID_FIELD_NAME));
@@ -39,11 +41,17 @@ public abstract class AbstractTransactionSummaryService implements TransactionSu
   }
 
   @Override
-  public Future<JsonObject> getTransactionSummary(Transaction transaction, DBClient client) {
-    logger.debug("Get summary={}", getSummaryId(transaction));
-    String summaryId = getSummaryId(transaction);
+  public Future<JsonObject> getTransactionSummary(String summaryId, DBClient client) {
+    logger.debug("Get summary by id: {}", summaryId);
 
     return transactionSummaryDao.getSummaryById(summaryId, client);
+  }
+
+  @Override
+  public Future<JsonObject> getTransactionSummaryWithLocking(String summaryId, Conn conn) {
+    logger.debug("Get summary by id: {} with locking", summaryId);
+
+    return transactionSummaryDao.getSummaryByIdWithLocking(summaryId, conn);
   }
 
   @Override

--- a/src/main/java/org/folio/service/summary/TransactionSummaryService.java
+++ b/src/main/java/org/folio/service/summary/TransactionSummaryService.java
@@ -3,11 +3,14 @@ package org.folio.service.summary;
 import io.vertx.core.Future;
 import io.vertx.core.json.JsonObject;
 import org.folio.rest.jaxrs.model.Transaction;
+import org.folio.rest.persist.Conn;
 import org.folio.rest.persist.DBClient;
 
 public interface TransactionSummaryService {
 
-  Future<JsonObject> getTransactionSummary(Transaction transaction, DBClient client);
+  Future<JsonObject> getTransactionSummary(String summaryId, DBClient client);
+
+  Future<JsonObject> getTransactionSummaryWithLocking(String summaryId, Conn conn);
 
   Future<Void> setTransactionsSummariesProcessed(JsonObject summary, DBClient client);
 

--- a/src/main/java/org/folio/service/transactions/AllOrNothingTransactionService.java
+++ b/src/main/java/org/folio/service/transactions/AllOrNothingTransactionService.java
@@ -155,7 +155,7 @@ public class AllOrNothingTransactionService {
   private Future<List<Transaction>> addTempTransactionSequentially(Transaction transaction, DBClient client) {
     final String tenantId = client.getTenantId();
     final String summaryId = transactionSummaryService.getSummaryId(transaction);
-    return client.getPgClient().withTrans(conn -> transactionSummaryService.getTransactionSummaryWithLocking(summaryId, conn)
+    return client.getPgClient().withConn(conn -> transactionSummaryService.getTransactionSummaryWithLocking(summaryId, conn)
       .compose(ar -> temporaryTransactionDAO.createTempTransaction(transaction, summaryId, tenantId, conn))
       .compose(tr -> temporaryTransactionDAO.getTempTransactionsBySummaryId(summaryId, conn)));
   }

--- a/src/main/java/org/folio/service/transactions/AllOrNothingTransactionService.java
+++ b/src/main/java/org/folio/service/transactions/AllOrNothingTransactionService.java
@@ -154,7 +154,7 @@ public class AllOrNothingTransactionService {
    */
   private Future<List<Transaction>> addTempTransactionSequentially(Transaction transaction, DBClient client) {
     final String summaryId = transactionSummaryService.getSummaryId(transaction);
-    return client.getPgClient().withConn(conn -> transactionSummaryService.getTransactionSummaryWithLocking(summaryId, conn)
+    return client.getPgClient().withTrans(conn -> transactionSummaryService.getTransactionSummaryWithLocking(summaryId, conn)
       .compose(ar -> temporaryTransactionDAO.createTempTransaction(transaction, summaryId, client)
         .compose(tr -> temporaryTransactionDAO.getTempTransactionsBySummaryId(summaryId, client))));
   }

--- a/src/main/java/org/folio/service/transactions/AllOrNothingTransactionService.java
+++ b/src/main/java/org/folio/service/transactions/AllOrNothingTransactionService.java
@@ -146,7 +146,7 @@ public class AllOrNothingTransactionService {
    * So in this case requests to create temp transaction and get temp transaction count for the same summaryId
    * will be executed only by a single thread.
    * The other thread will wait until DB Lock is released when the connection is closed.
-   * Method {@link org.folio.rest.persist.PostgresClient#withConn(Function)} closes connection after executing.
+   * Method {@link org.folio.rest.persist.PostgresClient#withTrans(Function)} closes connection after executing.
    *
    * @param transaction temp transaction to create
    * @param client the db client

--- a/src/main/java/org/folio/service/transactions/AllOrNothingTransactionService.java
+++ b/src/main/java/org/folio/service/transactions/AllOrNothingTransactionService.java
@@ -155,7 +155,7 @@ public class AllOrNothingTransactionService {
   private Future<List<Transaction>> addTempTransactionSequentially(Transaction transaction, DBClient client) {
     final String tenantId = client.getTenantId();
     final String summaryId = transactionSummaryService.getSummaryId(transaction);
-    return client.getPgClient().withConn(conn -> transactionSummaryService.getTransactionSummaryWithLocking(summaryId, conn)
+    return client.getPgClient().withTrans(conn -> transactionSummaryService.getTransactionSummaryWithLocking(summaryId, conn)
       .compose(ar -> temporaryTransactionDAO.createTempTransaction(transaction, summaryId, tenantId, conn))
       .compose(tr -> temporaryTransactionDAO.getTempTransactionsBySummaryId(summaryId, conn)));
   }

--- a/src/main/java/org/folio/service/transactions/AllOrNothingTransactionService.java
+++ b/src/main/java/org/folio/service/transactions/AllOrNothingTransactionService.java
@@ -145,8 +145,8 @@ public class AllOrNothingTransactionService {
    * This method uses SELECT FOR UPDATE locking on summary table by summaryId.
    * So in this case requests to create temp transaction and get temp transaction count for the same summaryId
    * will be executed only by a single thread.
-   * The other thread will wait until DB Lock is released when the connection is closed.
-   * Method {@link org.folio.rest.persist.PostgresClient#withTrans(Function)} closes connection after executing.
+   * The other thread will wait until DB Lock is released when the database transaction ends.
+   * Method {@link org.folio.rest.persist.PostgresClient#withTrans(Function)} ends the database transaction after executing.
    *
    * @param transaction temp transaction to create
    * @param client the db client

--- a/src/main/java/org/folio/service/transactions/AllOrNothingTransactionService.java
+++ b/src/main/java/org/folio/service/transactions/AllOrNothingTransactionService.java
@@ -153,10 +153,11 @@ public class AllOrNothingTransactionService {
    * @return future with list of temp transactions
    */
   private Future<List<Transaction>> addTempTransactionSequentially(Transaction transaction, DBClient client) {
+    final String tenantId = client.getTenantId();
     final String summaryId = transactionSummaryService.getSummaryId(transaction);
     return client.getPgClient().withTrans(conn -> transactionSummaryService.getTransactionSummaryWithLocking(summaryId, conn)
-      .compose(ar -> temporaryTransactionDAO.createTempTransaction(transaction, summaryId, client)
-        .compose(tr -> temporaryTransactionDAO.getTempTransactionsBySummaryId(summaryId, client))));
+      .compose(ar -> temporaryTransactionDAO.createTempTransaction(transaction, summaryId, tenantId, conn))
+      .compose(tr -> temporaryTransactionDAO.getTempTransactionsBySummaryId(summaryId, conn)));
   }
 
 }

--- a/src/main/java/org/folio/service/transactions/TemporaryTransactionService.java
+++ b/src/main/java/org/folio/service/transactions/TemporaryTransactionService.java
@@ -26,7 +26,8 @@ public class TemporaryTransactionService {
       .withOperation("AND")
       .withJson("fromFundId", "=", budget.getFundId());
 
-    return temporaryTransactionDAO.getTempTransactions(criterionBuilder.build(), client);
+    return client.getPgClient()
+      .withTrans(conn -> temporaryTransactionDAO.getTempTransactions(criterionBuilder.build(), conn));
   }
 
 }

--- a/src/main/java/org/folio/service/transactions/TemporaryTransactionService.java
+++ b/src/main/java/org/folio/service/transactions/TemporaryTransactionService.java
@@ -27,7 +27,7 @@ public class TemporaryTransactionService {
       .withJson("fromFundId", "=", budget.getFundId());
 
     return client.getPgClient()
-      .withTrans(conn -> temporaryTransactionDAO.getTempTransactions(criterionBuilder.build(), conn));
+      .withConn(conn -> temporaryTransactionDAO.getTempTransactions(criterionBuilder.build(), conn));
   }
 
 }

--- a/src/test/java/org/folio/service/transactions/EncumbranceServiceTest.java
+++ b/src/test/java/org/folio/service/transactions/EncumbranceServiceTest.java
@@ -120,7 +120,7 @@ public class EncumbranceServiceTest {
     doReturn(succeededFuture(trSummary)).when(mockTransactionSummaryService).getAndCheckTransactionSummary(eq(incomingTransaction), any(DBClient.class));
     doReturn(orderId).when(mockTransactionSummaryService).getSummaryId(eq(incomingTransaction));
     doReturn(pgClient).when(mockDBClient).getPgClient();
-    doReturn(succeededFuture(List.of(incomingTransaction))).when(pgClient).withConn(any());
+    doReturn(succeededFuture(List.of(incomingTransaction))).when(pgClient).withTrans(any());
     doReturn(1).when(mockTransactionSummaryService).getNumTransactions(eq(trSummary));
     doReturn(succeededFuture(null)).when(mockTransactionSummaryService).setTransactionsSummariesProcessed(eq(trSummary), any(DBClient.class));
     doReturn(succeededFuture(1)).when(mockTemporaryTransactionDAO).deleteTempTransactions(eq(orderId), any(DBClient.class));

--- a/src/test/java/org/folio/service/transactions/EncumbranceServiceTest.java
+++ b/src/test/java/org/folio/service/transactions/EncumbranceServiceTest.java
@@ -120,7 +120,7 @@ public class EncumbranceServiceTest {
     doReturn(succeededFuture(trSummary)).when(mockTransactionSummaryService).getAndCheckTransactionSummary(eq(incomingTransaction), any(DBClient.class));
     doReturn(orderId).when(mockTransactionSummaryService).getSummaryId(eq(incomingTransaction));
     doReturn(pgClient).when(mockDBClient).getPgClient();
-    doReturn(succeededFuture(List.of(incomingTransaction))).when(pgClient).withTrans(any());
+    doReturn(succeededFuture(List.of(incomingTransaction))).when(pgClient).withConn(any());
     doReturn(1).when(mockTransactionSummaryService).getNumTransactions(eq(trSummary));
     doReturn(succeededFuture(null)).when(mockTransactionSummaryService).setTransactionsSummariesProcessed(eq(trSummary), any(DBClient.class));
     doReturn(succeededFuture(1)).when(mockTemporaryTransactionDAO).deleteTempTransactions(eq(orderId), any(DBClient.class));


### PR DESCRIPTION
https://issues.folio.org/browse/MODFISTO-377

We use SELECT FOR UPDATE locking on summary table by summaryId.
In this case requests to create temp transaction and get temp transaction count for the same summaryId
will be executed only by a single thread by the single instance of the module.
The other thread will wait until DB Lock is released when the connection is closed.
Method {@link org.folio.rest.persist.PostgresClient#withConn(Function)} closes connection after executing.