### PR TITLE
MODFISTO-430 Improve error handling for test ledger rollovers where orders belong to several ledgers and calculate result budget

### DIFF
--- a/src/main/resources/templates/db_scripts/budget_encumbrances_rollover.sql
+++ b/src/main/resources/templates/db_scripts/budget_encumbrances_rollover.sql
@@ -261,8 +261,7 @@ CREATE OR REPLACE FUNCTION ${myuniversity}_${mymodule}.rollover_order(_order_id 
                                   AND budget.fiscalYearId::text = _rollover_record->>'toFiscalYearId'
                                   AND budget.ledgerRolloverId::text = _rollover_record->>'id')
                     AND tr.jsonb->'encumbrance'->>'sourcePurchaseOrderId'= _order_id
-                    AND tr.fiscalYearId::text= _rollover_record->>'fromFiscalYearId'
-                    AND (_rollover_record->>'rolloverType' <> 'Preview' OR (_rollover_record->>'rolloverType' = 'Preview' AND fund.ledgerId::text = _rollover_record->>'ledgerId'));
+                    AND tr.fiscalYearId::text= _rollover_record->>'fromFiscalYearId';
         ELSEIF
             -- #7
             (_rollover_record->>'restrictEncumbrance')::boolean AND EXISTS (SELECT sum((tr.jsonb->>'amount')::decimal) FROM tmp_transaction tr


### PR DESCRIPTION
[MODFISTO-430](https://issues.folio.org/browse/MODFISTO-430)

<!--
  If you have a relevant JIRA issue number, please put it in the issue title.
  Example: MODFISTO-70 Logging Improvement

  TL;DR
    - https://www.youtube.com/watch?v=5aHmO_S8FQ4
    - http://www.olitreadwell.com/2016/05/22/how-to-write-great-pull-requests/
    - https://www.atlassian.com/blog/git/written-unwritten-guide-pull-requests
-->

## Purpose
### Error handling changes:

There could be 2 possible error message returned for Rollover Preview in case order uses several ledgers and some of them are not rollovered yet:

1. Part of the encumbrances belong to the ledger, which has not been rollovered
2. Budget not found

Expected behaviour in this case is to always have same error(first one)
The reason why second error might be returned is that when order is checked for related not rollovered ledgers, "preview" rollovers are taken into account.
 
So if, let's say, order uses 2 ledgers, ledger1 and ledger2, when  rollover preview for ledger1 is called, there's `Part of the encumbrances belong to the ledger, which has not been rollovered`  error added for this order.
However rollover preview for ledger 2 will incorrectly treat existing "preview" rollover as a completed rollover and bypass this validation as the result. It'll fail later with `Budget not found` error, which is undesired behaviour

### Test rollover result calculation: 
preview failed without calculating result budget for the ledger in case of cross-ledger orders

<!--
  Why are you making this change? There is nothing more important
  to provide to the reviewer and to future readers than the cause
  that gave rise to this pull request. Be careful to avoid circular
  statements like "the purpose is to update the schema."
  instead, provide an explanation like "there is more data to be provided and stored for Purchase Orders
  which is currently missing in the schema"

  The purpose may seem self-evident to you now, but the standard to
  hold yourself to should be "can a developer parachuting into this
  the project reconstructs the necessary context merely by reading this
  section."

  If you have a relevant JIRA issue, add a link directly to the issue URL here.
  Example: https://issues.folio.org/browse/MODFISTO-70
 -->

## Approach
### Error handling:
1. To fix this, checking for "Preview" rollover type was added to query which selects order's related ledgers which are not rollovered yet. "Preview" rollovers won't be taken into account.
2. Also error message was improved: it mentions that it's a warning and contains ledger identifiers which need to be rollovered.
Ex.: ` [WARNING] Part of the encumbrances belong to the ledger, which has not been rollovered. Ledgers to rollover: TestLedger2 (id=c3a90ac7-26f7-4077-b1db-f80b927be0ad)`

### Result budget preview calculation:
In case of rollover preview, there'll be errors about other ledgers not rollovered. Other  validation errors and result budget will be calculated disregarding other ledgers.

### Example
Orderlines are linked to different ledgers:
![image](https://github.com/folio-org/mod-finance-storage/assets/11651407/9cad00f1-5f7e-4ae7-8200-1a05bb12f6b6)

Error for test rollover of first ledger:
`[WARNING] Part of the encumbrances belong to the ledger, which has not been rollovered. Ledgers to rollover: TestLedger222 (id=955bc482-b2a1-4861-abb8-45b62d2d0784)`

Result budget calculated taking into account ledger's encumbrances:
```json{
	"id": "5dbe7025-92ee-5d1e-9f10-71d88b83b475",
	"name": "Fund111-FYTest2024",
	"fundId": "80dc2d77-7962-4895-ae7d-bcb7f3feca35",
	"_version": 4,
	"budgetId": "5dbe7025-92ee-5d1e-9f10-71d88b83b475",
	"metadata": {
		"createdDate": "2023-06-15T10:18:39.251Z",
		"updatedDate": "2023-06-15T10:18:39.251Z",
		"createdByUserId": "ff96b580-4206-4957-8b5d-7bdbc3d192f9",
		"updatedByUserId": "ff96b580-4206-4957-8b5d-7bdbc3d192f9"
	},
	"allocated": 400,
	"available": 365,
	"acqUnitIds": [],
	"encumbered": 35,
	"cashBalance": 400,
	"fundDetails": {
		"id": "80dc2d77-7962-4895-ae7d-bcb7f3feca35",
		"code": "Fund111",
		"name": "Fund111",
		"acqUnitIds": [],
		"fundStatus": "Active",
		"allocatedToIds": [],
		"allocatedFromIds": [],
		"allocatedToNames": [],
		"externalAccountNo": "456",
		"allocatedFromNames": []
	},
	"unavailable": 35,
	"allocationTo": 0,
	"budgetStatus": "Active",
	"expenditures": 0,
	"fiscalYearId": "437d45f5-837d-4e6c-ac21-c7c2863a2b15",
	"netTransfers": 0,
	"overExpended": 0,
	"totalFunding": 400,
	"allocationFrom": 0,
	"awaitingPayment": 0,
	"overEncumbrance": 0,
	"ledgerRolloverId": "e289ce6c-a3e0-40f4-9dc5-724d7f6ae0f4",
	"initialAllocation": 400,
	"expenseClassDetails": [],
	"allowableEncumbrance": 100,
	"allowableExpenditure": 100
}
```

Note: currently on UI it's possible to see only the error files. It needs to be updated to show results as well:
![image](https://github.com/folio-org/mod-finance-storage/assets/11651407/e8d65c64-7e49-45f9-9ff4-ec0b954e4940)


<!--
 How does this change fulfill the purpose? It's best to talk
 high-level strategy and avoid code-splaining the commit history.

 The goal is not only to explain what you did but help other
 developers *work* with your solution in the future.
-->

#### TODOS and Open Questions
<!-- OPTIONAL
- [ ] Use GitHub checklists. When solved, check the box and explain the answer.
- [ ] Check logging.
-->

## Learning
<!-- OPTIONAL
  Help out not only your reviewer but also your fellow developer!
  Sometimes there are key pieces of information that you used to come up
  with your solution. Don't let all that hard work go to waste! A
  pull request is a perfect opportunity to share the learning that
  you did. Add links to blog posts, patterns, libraries or add-ons used
  to solve this problem.
-->

## Pre-Merge Checklist:
Before merging this PR, please go through the following list and take appropriate actions.

- Does this PR meet or exceed the expected quality standards?
  - [ ] Code coverage on new code is 80% or greater
  - [ ] Duplications on new code is 3% or less
  - [ ] There are no major code smells or security issues
- Does this introduce breaking changes?
  - [ ] Were any API paths or methods changed, added or removed?
  - [ ] Were there any schema changes?
  - [ ] Did any of the interface versions change?
  - [ ] Were permissions changed, added or removed?
  - [ ] Are there new interface dependencies?
  - [ ] There are no breaking changes in this PR.

If there are breaking changes, please **STOP** and consider the following:

- What other modules will these changes impact?
- Do JIRAs exist to update the impacted modules?
  - [ ] If not, please create them
  - [ ] Do they contain the appropriate level of detail?  Which endpoints/schemas changed, etc.
  - [ ] Do they have all the appropriate links to blocked/related issues?
- Are the JIRAs under active development?
  - [ ] If not, contact the project's PO and make sure they're aware of the urgency.
- Do PRs exist for these changes?
  - [ ] If so, have they been approved?
- Did you modify code to call some additional endpoints?
  - [ ] If so, do you check that necessary module permission added in ModuleDescriptor-template.yaml file?

Ideally, all the PRs involved in breaking changes would be merged on the same day
to avoid breaking the folio-testing environment.
Communication is paramount if that is to be achieved,
especially as the number of inter-module and inter-team dependencies increase.

While it's helpful for reviewers to help identify potential problems,
ensuring that it's safe to merge is ultimately the responsibility of the PR assignee.
