### PR TITLE
[MODFISTO-441] - Add the ability to skip the transaction if it is from the previous year

### DIFF
--- a/src/main/resources/templates/db_scripts/budget_encumbrances_rollover.sql
+++ b/src/main/resources/templates/db_scripts/budget_encumbrances_rollover.sql
@@ -330,7 +330,7 @@ CREATE OR REPLACE FUNCTION ${myuniversity}_${mymodule}.rollover_order(_order_id 
                 -- tmp_encumbered_transactions contains data for all orders with updated encumbered field
                 INSERT INTO tmp_encumbered_transactions SELECT * FROM tmp_transaction;
             ELSE
-                INSERT INTO ${myuniversity}_${mymodule}.transaction SELECT * FROM tmp_transaction;
+                INSERT INTO ${myuniversity}_${mymodule}.transaction SELECT * FROM tmp_transaction ON CONFLICT (id) DO NOTHING;
             END IF;
         END IF;
 
@@ -644,7 +644,7 @@ CREATE OR REPLACE FUNCTION ${myuniversity}_${mymodule}.budget_encumbrances_rollo
               );
 
         IF _rollover_record->>'rolloverType' <> 'Preview' THEN
-            INSERT INTO ${myuniversity}_${mymodule}.transaction SELECT * FROM tmp_transaction;
+            INSERT INTO ${myuniversity}_${mymodule}.transaction SELECT * FROM tmp_transaction ON CONFLICT (id) DO NOTHING;
         END IF;
 
         DROP TABLE IF EXISTS tmp_transaction;


### PR DESCRIPTION
## Purpose
To generate unique encumbrances, the stored function "uuid_generate_v5(namespace uuid, name text)" from the "uuid-ossp" module is utilized. To resolve the problem, it is proposed to ignore the encumbrance from the previous year during the insertion into the "transaction" table. This will ensure uniqueness of encumbrances within each year and prevent the duplication of primary keys in the "transaction" table during the roll-over process. Consequently, each new year will have its own distinct encumbrances, resolving the issue of transaction overflow between years.

## Approach

- skip insert process on transaction talbe when happening conflict by id

#### TODOS and Open Questions
<!-- OPTIONAL
- [ ] Use GitHub checklists. When solved, check the box and explain the answer.
- [ ] Check logging.
-->

## Learning
[MODFISTO-441](https://issues.folio.org/browse/MODFISTO-441)

## Pre-Merge Checklist:
Before merging this PR, please go through the following list and take appropriate actions.

- Does this PR meet or exceed the expected quality standards?
  - [ ] Code coverage on new code is 80% or greater
  - [ ] Duplications on new code is 3% or less
  - [ ] There are no major code smells or security issues
- Does this introduce breaking changes?
  - [ ] Were any API paths or methods changed, added or removed?
  - [ ] Were there any schema changes?
  - [ ] Did any of the interface versions change?
  - [ ] Were permissions changed, added or removed?
  - [ ] Are there new interface dependencies?
  - [ ] There are no breaking changes in this PR.

If there are breaking changes, please **STOP** and consider the following:

- What other modules will these changes impact?
- Do JIRAs exist to update the impacted modules?
  - [ ] If not, please create them
  - [ ] Do they contain the appropriate level of detail?  Which endpoints/schemas changed, etc.
  - [ ] Do they have all the appropriate links to blocked/related issues?
- Are the JIRAs under active development?
  - [ ] If not, contact the project's PO and make sure they're aware of the urgency.
- Do PRs exist for these changes?
  - [ ] If so, have they been approved?
- Did you modify code to call some additional endpoints?
  - [ ] If so, do you check that necessary module permission added in ModuleDescriptor-template.yaml file?

Ideally, all the PRs involved in breaking changes would be merged on the same day
to avoid breaking the folio-testing environment.
Communication is paramount if that is to be achieved,
especially as the number of inter-module and inter-team dependencies increase.

While it's helpful for reviewers to help identify potential problems,
ensuring that it's safe to merge is ultimately the responsibility of the PR assignee.
