### PR TITLE
[MODFISTO-443] - Allow user to decrease allocation resulting in a negative available amount

### DIFF
--- a/src/main/java/org/folio/service/budget/BudgetService.java
+++ b/src/main/java/org/folio/service/budget/BudgetService.java
@@ -3,6 +3,8 @@ package org.folio.service.budget;
 import static java.util.stream.Collectors.toList;
 import static org.folio.rest.impl.BudgetAPI.BUDGET_TABLE;
 import static org.folio.rest.impl.FundAPI.FUND_TABLE;
+import static org.folio.rest.jaxrs.model.Transaction.TransactionType.ALLOCATION;
+import static org.folio.rest.jaxrs.model.Transaction.TransactionType.TRANSFER;
 import static org.folio.rest.persist.HelperUtils.getFullTableName;
 import static org.folio.rest.persist.HelperUtils.getQueryValues;
 import static org.folio.rest.util.ErrorCodes.*;
@@ -40,6 +42,7 @@ public class BudgetService {
 
   private static final String GROUP_FUND_FY_TABLE = "group_fund_fiscal_year";
   private static final String TRANSACTIONS_TABLE = "transaction";
+  private static final Set<Transaction.TransactionType> BYPASS_BUDGET_CHECK_TYPES = Set.of(TRANSFER, ALLOCATION);
   public static final String TRANSACTION_IS_PRESENT_BUDGET_DELETE_ERROR = "transactionIsPresentBudgetDeleteError";
 
   public static final String SELECT_BUDGETS_BY_FY_AND_FUND_FOR_UPDATE = "SELECT jsonb FROM %s "
@@ -231,7 +234,7 @@ public class BudgetService {
   }
 
   public Future<Void> checkBudgetHaveMoneyForTransaction(Transaction transaction, DBClient client) {
-    if (Objects.isNull(transaction.getFromFundId()) || transaction.getTransactionType() == Transaction.TransactionType.TRANSFER) {
+    if (Objects.isNull(transaction.getFromFundId()) || BYPASS_BUDGET_CHECK_TYPES.contains(transaction.getTransactionType())) {
       return Future.succeededFuture();
     }
 

--- a/src/main/java/org/folio/service/budget/BudgetService.java
+++ b/src/main/java/org/folio/service/budget/BudgetService.java
@@ -3,8 +3,6 @@ package org.folio.service.budget;
 import static java.util.stream.Collectors.toList;
 import static org.folio.rest.impl.BudgetAPI.BUDGET_TABLE;
 import static org.folio.rest.impl.FundAPI.FUND_TABLE;
-import static org.folio.rest.jaxrs.model.Transaction.TransactionType.ALLOCATION;
-import static org.folio.rest.jaxrs.model.Transaction.TransactionType.TRANSFER;
 import static org.folio.rest.persist.HelperUtils.getFullTableName;
 import static org.folio.rest.persist.HelperUtils.getQueryValues;
 import static org.folio.rest.util.ErrorCodes.*;
@@ -42,7 +40,6 @@ public class BudgetService {
 
   private static final String GROUP_FUND_FY_TABLE = "group_fund_fiscal_year";
   private static final String TRANSACTIONS_TABLE = "transaction";
-  private static final Set<Transaction.TransactionType> BYPASS_BUDGET_CHECK_TYPES = Set.of(TRANSFER, ALLOCATION);
   public static final String TRANSACTION_IS_PRESENT_BUDGET_DELETE_ERROR = "transactionIsPresentBudgetDeleteError";
 
   public static final String SELECT_BUDGETS_BY_FY_AND_FUND_FOR_UPDATE = "SELECT jsonb FROM %s "
@@ -234,7 +231,7 @@ public class BudgetService {
   }
 
   public Future<Void> checkBudgetHaveMoneyForTransaction(Transaction transaction, DBClient client) {
-    if (Objects.isNull(transaction.getFromFundId()) || BYPASS_BUDGET_CHECK_TYPES.contains(transaction.getTransactionType())) {
+    if (Objects.isNull(transaction.getFromFundId()) || transaction.getTransactionType() == Transaction.TransactionType.TRANSFER) {
       return Future.succeededFuture();
     }
 

--- a/src/main/java/org/folio/service/budget/BudgetService.java
+++ b/src/main/java/org/folio/service/budget/BudgetService.java
@@ -231,7 +231,8 @@ public class BudgetService {
   }
 
   public Future<Void> checkBudgetHaveMoneyForTransaction(Transaction transaction, DBClient client) {
-    if (Objects.isNull(transaction.getFromFundId()) || transaction.getTransactionType() == Transaction.TransactionType.TRANSFER) {
+    if (Objects.isNull(transaction.getFromFundId()) || isDecreaseAllocation(transaction)
+      || transaction.getTransactionType() == Transaction.TransactionType.TRANSFER) {
       return Future.succeededFuture();
     }
 
@@ -265,6 +266,11 @@ public class BudgetService {
   private String getSelectBudgetQueryByFyAndFundForUpdate(String tenantId){
     String budgetTableName = getFullTableName(tenantId, BUDGET_TABLE);
     return String.format(SELECT_BUDGETS_BY_FY_AND_FUND_FOR_UPDATE, budgetTableName);
+  }
+
+  private boolean isDecreaseAllocation(Transaction transaction) {
+    return Objects.nonNull(transaction.getFromFundId()) && Objects.isNull(transaction.getToFundId())
+      && transaction.getTransactionType() == Transaction.TransactionType.ALLOCATION;
   }
 
 }

--- a/src/main/java/org/folio/service/transactions/TransferService.java
+++ b/src/main/java/org/folio/service/transactions/TransferService.java
@@ -48,7 +48,6 @@ public class TransferService extends AbstractTransactionService implements Trans
     DBClient client = new DBClient(requestContext);
 
     client.startTx()
-      .compose(v -> budgetService.checkBudgetHaveMoneyForTransaction(transfer, client))
       .compose(v -> createTransfer(transfer, client)
         .compose(createdTransfer -> {
         if (transfer.getFromFundId() != null) {


### PR DESCRIPTION
## Purpose
Remove the limits on decreasing allocated amount.

## Approach

- When fromFundId is not null and transfer type is allocation it means that decrease allocation action. Was decided to bypass the check by adding 'Allocation' type to filter in the beggining of the method

#### TODOS and Open Questions
<!-- OPTIONAL
- [ ] Use GitHub checklists. When solved, check the box and explain the answer.
- [ ] Check logging.
-->

## Learning
[MODFISTO-443](https://issues.folio.org/browse/MODFISTO-443)

## Pre-Merge Checklist:
Before merging this PR, please go through the following list and take appropriate actions.

- Does this PR meet or exceed the expected quality standards?
  - [x] Code coverage on new code is 80% or greater
  - [x] Duplications on new code is 3% or less
  - [x] There are no major code smells or security issues
- Does this introduce breaking changes?
  - [ ] Were any API paths or methods changed, added or removed?
  - [ ] Were there any schema changes?
  - [ ] Did any of the interface versions change?
  - [ ] Were permissions changed, added or removed?
  - [ ] Are there new interface dependencies?
  - [ ] There are no breaking changes in this PR.

If there are breaking changes, please **STOP** and consider the following:

- What other modules will these changes impact?
- Do JIRAs exist to update the impacted modules?
  - [ ] If not, please create them
  - [ ] Do they contain the appropriate level of detail?  Which endpoints/schemas changed, etc.
  - [ ] Do they have all the appropriate links to blocked/related issues?
- Are the JIRAs under active development?
  - [ ] If not, contact the project's PO and make sure they're aware of the urgency.
- Do PRs exist for these changes?
  - [ ] If so, have they been approved?
- Did you modify code to call some additional endpoints?
  - [ ] If so, do you check that necessary module permission added in ModuleDescriptor-template.yaml file?

Ideally, all the PRs involved in breaking changes would be merged on the same day
to avoid breaking the folio-testing environment.
Communication is paramount if that is to be achieved,
especially as the number of inter-module and inter-team dependencies increase.

While it's helpful for reviewers to help identify potential problems,
ensuring that it's safe to merge is ultimately the responsibility of the PR assignee.
