### PR TITLE
MODFISTO-446: Creating budget fails with trailing junk "$2F"

### DIFF
--- a/src/main/java/org/folio/service/budget/BudgetService.java
+++ b/src/main/java/org/folio/service/budget/BudgetService.java
@@ -44,7 +44,7 @@ public class BudgetService {
   public static final String TRANSACTION_IS_PRESENT_BUDGET_DELETE_ERROR = "transactionIsPresentBudgetDeleteError";
 
   public static final String SELECT_BUDGETS_BY_FY_AND_FUND_FOR_UPDATE = "SELECT jsonb FROM %s "
-    + "WHERE jsonb->>'fiscalYearId' = $1 AND jsonb->>'fundId' = $2"
+    + "WHERE jsonb->>'fiscalYearId' = $1 AND jsonb->>'fundId' = $2 "
     + "FOR UPDATE";
 
   private BudgetDAO budgetDAO;


### PR DESCRIPTION
Missing space results in SQL syntax error in BudgetService when using PostgreSQL 15, 16 or any later version.
https://issues.folio.org/browse/MODFISTO-446