### PR TITLE
MODFISTO-450: Fix invalid test tenant ids

### DIFF
--- a/src/test/java/org/folio/rest/impl/BudgetTest.java
+++ b/src/test/java/org/folio/rest/impl/BudgetTest.java
@@ -41,7 +41,7 @@ import io.vertx.core.json.JsonObject;
 public class BudgetTest extends TestBase {
 
   private static final String BUDGET_ENDPOINT = TestEntities.BUDGET.getEndpoint();
-  private static final String BUDGET_TEST_TENANT = "budget_test_tenant_api";
+  private static final String BUDGET_TEST_TENANT = "budgettesttenantapi";
   private static final Header BUDGET_TENANT_HEADER = new Header(OKAPI_HEADER_TENANT, BUDGET_TEST_TENANT);
   private static final String ENCUMBR_SAMPLE = "data/transactions/encumbrances/encumbrance_AFRICAHIST_306857_1.json";
   private static TenantJob tenantJob;

--- a/src/test/java/org/folio/rest/impl/GroupFundFYTest.java
+++ b/src/test/java/org/folio/rest/impl/GroupFundFYTest.java
@@ -13,7 +13,7 @@ import io.restassured.http.Header;
 
 public class GroupFundFYTest extends TestBase {
 
-  private static final Header GROUP_FUND_FY_TENANT_HEADER = new Header(OKAPI_HEADER_TENANT, "GROUP_FUND_FY");
+  private static final Header GROUP_FUND_FY_TENANT_HEADER = new Header(OKAPI_HEADER_TENANT, "groupfundfy");
 
   @Test
   public void testGetQuery() throws Exception {

--- a/src/test/java/org/folio/rest/impl/GroupTest.java
+++ b/src/test/java/org/folio/rest/impl/GroupTest.java
@@ -19,7 +19,7 @@ import static org.folio.rest.utils.TestEntities.GROUP;
 import static org.folio.rest.utils.TestEntities.LEDGER;
 
 public class GroupTest extends TestBase {
-  private static final String GROUP_TEST_TENANT = "group_test_tenant";
+  private static final String GROUP_TEST_TENANT = "grouptesttenant";
   private static final Header GROUP_TENANT_HEADER = new Header(OKAPI_HEADER_TENANT, GROUP_TEST_TENANT);
   private static TenantJob tenantJob;
 

--- a/src/test/java/org/folio/rest/impl/TenantSampleDataTest.java
+++ b/src/test/java/org/folio/rest/impl/TenantSampleDataTest.java
@@ -28,7 +28,7 @@ public class TenantSampleDataTest extends TestBase {
 
   private final Logger logger = LogManager.getLogger(TenantSampleDataTest.class);
 
-  private static final Header ANOTHER_TENANT_HEADER = new Header(OKAPI_HEADER_TENANT, "new_tenant");
+  private static final Header ANOTHER_TENANT_HEADER = new Header(OKAPI_HEADER_TENANT, "newtenant");
 
   private static TenantJob tenantJob;
 

--- a/src/test/java/org/folio/rest/impl/TransactionTest.java
+++ b/src/test/java/org/folio/rest/impl/TransactionTest.java
@@ -39,7 +39,7 @@ public class TransactionTest extends TestBase {
 
   protected static final String TRANSACTION_ENDPOINT = ALLOCATION_TRANSACTION.getEndpoint();
   protected static final String TRANSACTION_ENDPOINT_BY_ID = ALLOCATION_TRANSACTION.getEndpointWithId();
-  protected static final String TRANSACTION_TEST_TENANT = "transaction_test_tenant";
+  protected static final String TRANSACTION_TEST_TENANT = "transactiontesttenant";
   protected static final Header TRANSACTION_TENANT_HEADER = new Header(OKAPI_HEADER_TENANT, TRANSACTION_TEST_TENANT);
 
   private static final String FY_FUND_QUERY = "?query=fiscalYearId==%s AND fundId==%s";

--- a/src/test/java/org/folio/service/email/EmailServiceTest.java
+++ b/src/test/java/org/folio/service/email/EmailServiceTest.java
@@ -53,7 +53,7 @@ public class EmailServiceTest {
 
   private Vertx vertx;
   private RequestContext mockRequestContext;
-  private static final String TEST_TENANT = "test_tenant";
+  private static final String TEST_TENANT = "testtenant";
   private static final String OKAPI_TOKEN = "x-okapi-token";
   private static final String OKAPI_URL = "x-okapi-url";
   private static final String OKAPI_TENANT = "x-okapi-tenant";


### PR DESCRIPTION
https://issues.folio.org/browse/MODFISTO-450

https://wiki.folio.org/display/TC/DR-000002+-+Tenant+Id+and+Module+Name+Restrictions has been accepted by Technical Council June 2022.

Tests may fail in recent versions of RMB if the tenant id contains capital letters or underscores.

Rename test tenant ids to comply with the requirements.