### PR TITLE
[MODFISTO-461] - FYRO fails on duplicate encumbrance

### DIFF
--- a/src/main/resources/templates/db_scripts/budget_encumbrances_rollover.sql
+++ b/src/main/resources/templates/db_scripts/budget_encumbrances_rollover.sql
@@ -336,11 +336,22 @@ CREATE OR REPLACE FUNCTION ${myuniversity}_${mymodule}.rollover_order(_order_id 
                 INSERT INTO ${myuniversity}_${mymodule}.transaction
                 SELECT * FROM tmp_transaction t
                 WHERE NOT EXISTS (
-                  SELECT 1
-                  FROM ${myuniversity}_${mymodule}.transaction tr
-                  WHERE tr.id = t.id
-                  )
-                ON CONFLICT ON CONSTRAINT transaction_encumbrance_idx_unique DO NOTHING;
+                    SELECT 1
+                    FROM ${myuniversity}_${mymodule}.transaction tr
+                    WHERE tr.id = t.id
+                )
+                ON CONFLICT (lower(${myuniversity}_${mymodule}.f_unaccent(${myuniversity}_${mymodule}.concat_space_sql(
+                    VARIADIC ARRAY[
+                        (jsonb ->> 'amount'::text),
+                        (jsonb ->> 'fromFundId'::text),
+                        ((jsonb -> 'encumbrance'::text) ->> 'sourcePurchaseOrderId'::text),
+                        ((jsonb -> 'encumbrance'::text) ->> 'sourcePoLineId'::text),
+                        ((jsonb -> 'encumbrance'::text) ->> 'initialAmountEncumbered'::text),
+                        ((jsonb -> 'encumbrance'::text) ->> 'status'::text),
+                        (jsonb ->> 'expenseClassId'::text),
+                        (jsonb ->> 'fiscalYearId'::text)
+                    ]))))
+                WHERE ((jsonb ->> 'transactionType'::text) = 'Encumbrance'::text) DO NOTHING;
             END IF;
         END IF;
 
@@ -662,11 +673,22 @@ CREATE OR REPLACE FUNCTION ${myuniversity}_${mymodule}.budget_encumbrances_rollo
             INSERT INTO ${myuniversity}_${mymodule}.transaction
             SELECT * FROM tmp_transaction t
             WHERE NOT EXISTS (
-              SELECT 1
-              FROM ${myuniversity}_${mymodule}.transaction tr
-              WHERE tr.id = t.id
+                SELECT 1
+                FROM ${myuniversity}_${mymodule}.transaction tr
+                WHERE tr.id = t.id
             )
-            ON CONFLICT ON CONSTRAINT transaction_encumbrance_idx_unique DO NOTHING;
+            ON CONFLICT (lower(${myuniversity}_${mymodule}.f_unaccent(${myuniversity}_${mymodule}.concat_space_sql(
+                VARIADIC ARRAY[
+                    (jsonb ->> 'amount'::text),
+                    (jsonb ->> 'fromFundId'::text),
+                    ((jsonb -> 'encumbrance'::text) ->> 'sourcePurchaseOrderId'::text),
+                    ((jsonb -> 'encumbrance'::text) ->> 'sourcePoLineId'::text),
+                    ((jsonb -> 'encumbrance'::text) ->> 'initialAmountEncumbered'::text),
+                    ((jsonb -> 'encumbrance'::text) ->> 'status'::text),
+                    (jsonb ->> 'expenseClassId'::text),
+                    (jsonb ->> 'fiscalYearId'::text)
+                ]))))
+            WHERE ((jsonb ->> 'transactionType'::text) = 'Encumbrance'::text) DO NOTHING;
         END IF;
 
         DROP TABLE IF EXISTS tmp_transaction;

--- a/src/main/resources/templates/db_scripts/budget_encumbrances_rollover.sql
+++ b/src/main/resources/templates/db_scripts/budget_encumbrances_rollover.sql
@@ -340,7 +340,7 @@ CREATE OR REPLACE FUNCTION ${myuniversity}_${mymodule}.rollover_order(_order_id 
                   FROM ${myuniversity}_${mymodule}.transaction tr
                   WHERE tr.id = t.id
                   )
-                ON CONFLICT ON CONSTRAINT transaction_encumbrance_unique DO NOTHING;
+                ON CONFLICT ON CONSTRAINT transaction_encumbrance_idx_unique DO NOTHING;
             END IF;
         END IF;
 
@@ -666,7 +666,7 @@ CREATE OR REPLACE FUNCTION ${myuniversity}_${mymodule}.budget_encumbrances_rollo
               FROM ${myuniversity}_${mymodule}.transaction tr
               WHERE tr.id = t.id
             )
-            ON CONFLICT ON CONSTRAINT transaction_encumbrance_unique DO NOTHING;
+            ON CONFLICT ON CONSTRAINT transaction_encumbrance_idx_unique DO NOTHING;
         END IF;
 
         DROP TABLE IF EXISTS tmp_transaction;

--- a/src/main/resources/templates/db_scripts/budget_encumbrances_rollover.sql
+++ b/src/main/resources/templates/db_scripts/budget_encumbrances_rollover.sql
@@ -340,7 +340,7 @@ CREATE OR REPLACE FUNCTION ${myuniversity}_${mymodule}.rollover_order(_order_id 
                   FROM ${myuniversity}_${mymodule}.transaction tr
                   WHERE tr.id = t.id
                   )
-                ON CONFLICT ON CONSTRAINT transaction_encumbrance_idx_unique DO NOTHING;
+                ON CONFLICT ON CONSTRAINT transaction_encumbrance_unique DO NOTHING;
             END IF;
         END IF;
 
@@ -666,7 +666,7 @@ CREATE OR REPLACE FUNCTION ${myuniversity}_${mymodule}.budget_encumbrances_rollo
               FROM ${myuniversity}_${mymodule}.transaction tr
               WHERE tr.id = t.id
             )
-            ON CONFLICT ON CONSTRAINT transaction_encumbrance_idx_unique DO NOTHING;
+            ON CONFLICT ON CONSTRAINT transaction_encumbrance_unique DO NOTHING;
         END IF;
 
         DROP TABLE IF EXISTS tmp_transaction;

--- a/src/main/resources/templates/db_scripts/budget_encumbrances_rollover.sql
+++ b/src/main/resources/templates/db_scripts/budget_encumbrances_rollover.sql
@@ -333,6 +333,8 @@ CREATE OR REPLACE FUNCTION ${myuniversity}_${mymodule}.rollover_order(_order_id 
                 -- TODO: Need to rewrite with MERGE command after complete migration of PostgreSQL to version 16
                 -- Merge command: https://www.postgresql.org/docs/16/sql-merge.html
                 -- Confluence page about PostgreSQL migration: https://folio-org.atlassian.net/wiki/spaces/TC/pages/5057452/DR-000038+-+PostgreSQL+Upgrade+to+16#DR-000038-PostgreSQLUpgradeto16-16
+                -- ON CONFLICT (id) was replaced using WHERE NOT EXISTS due to unability PostgreSQL handling two or more unique indexes
+                -- At the moment ON CONFLICT refers to index definition of partial unique index with name transaction_encumbrance_idx_unique
                 INSERT INTO ${myuniversity}_${mymodule}.transaction
                 SELECT * FROM tmp_transaction t
                 WHERE NOT EXISTS (
@@ -670,6 +672,8 @@ CREATE OR REPLACE FUNCTION ${myuniversity}_${mymodule}.budget_encumbrances_rollo
             -- TODO: Need to rewrite with MERGE command after complete migration of PostgreSQL to version 16
             -- Merge command: https://www.postgresql.org/docs/16/sql-merge.html
             -- Confluence page about PostgreSQL migration: https://folio-org.atlassian.net/wiki/spaces/TC/pages/5057452/DR-000038+-+PostgreSQL+Upgrade+to+16#DR-000038-PostgreSQLUpgradeto16-16
+            -- ON CONFLICT (id) was replaced using WHERE NOT EXISTS due to unability PostgreSQL handling two or more unique indexes
+            -- At the moment ON CONFLICT refers to index definition of partial unique index with name transaction_encumbrance_idx_unique
             INSERT INTO ${myuniversity}_${mymodule}.transaction
             SELECT * FROM tmp_transaction t
             WHERE NOT EXISTS (

--- a/src/main/resources/templates/db_scripts/budget_encumbrances_rollover.sql
+++ b/src/main/resources/templates/db_scripts/budget_encumbrances_rollover.sql
@@ -656,9 +656,9 @@ CREATE OR REPLACE FUNCTION ${myuniversity}_${mymodule}.budget_encumbrances_rollo
               );
 
         IF _rollover_record->>'rolloverType' <> 'Preview' THEN
-          -- TODO: Need to rewrite with MERGE command after complete migration of PostgreSQL to version 16
-          -- Merge command: https://www.postgresql.org/docs/16/sql-merge.html
-          -- Confluence page about PostgreSQL migration: https://folio-org.atlassian.net/wiki/spaces/TC/pages/5057452/DR-000038+-+PostgreSQL+Upgrade+to+16#DR-000038-PostgreSQLUpgradeto16-16
+            -- TODO: Need to rewrite with MERGE command after complete migration of PostgreSQL to version 16
+            -- Merge command: https://www.postgresql.org/docs/16/sql-merge.html
+            -- Confluence page about PostgreSQL migration: https://folio-org.atlassian.net/wiki/spaces/TC/pages/5057452/DR-000038+-+PostgreSQL+Upgrade+to+16#DR-000038-PostgreSQLUpgradeto16-16
             INSERT INTO ${myuniversity}_${mymodule}.transaction
             SELECT * FROM tmp_transaction t
             WHERE NOT EXISTS (

--- a/src/main/resources/templates/db_scripts/schema.json
+++ b/src/main/resources/templates/db_scripts/schema.json
@@ -366,7 +366,7 @@
     },
     {
       "tableName": "transaction",
-      "fromModuleVersion": "mod-finance-storage-8.6.0",
+      "fromModuleVersion": "mod-finance-storage-7.1.0",
       "withMetadata": true,
       "withOptimisticLocking": "failOnConflict",
       "customSnippetPath": "transactions.sql",

--- a/src/main/resources/templates/db_scripts/schema.json
+++ b/src/main/resources/templates/db_scripts/schema.json
@@ -74,7 +74,7 @@
     {
       "run": "after",
       "snippetPath": "budget_encumbrances_rollover.sql",
-      "fromModuleVersion": "mod-finance-storage-8.5.0"
+      "fromModuleVersion": "mod-finance-storage-8.6.0"
     },
     {
       "run": "after",

--- a/src/main/resources/templates/db_scripts/schema.json
+++ b/src/main/resources/templates/db_scripts/schema.json
@@ -366,7 +366,7 @@
     },
     {
       "tableName": "transaction",
-      "fromModuleVersion": "mod-finance-storage-7.1.0",
+      "fromModuleVersion": "mod-finance-storage-8.6.0",
       "withMetadata": true,
       "withOptimisticLocking": "failOnConflict",
       "customSnippetPath": "transactions.sql",

--- a/src/main/resources/templates/db_scripts/transactions.sql
+++ b/src/main/resources/templates/db_scripts/transactions.sql
@@ -1,3 +1,6 @@
 DROP TRIGGER IF EXISTS recalculate_totals on ${myuniversity}_${mymodule}."transaction";
 DROP FUNCTION IF EXISTS ${myuniversity}_${mymodule}.recalculate_totals();
 
+ALTER TABLE ${myuniversity}_${mymodule}."transaction" DROP CONSTRAINT IF EXISTS transaction_encumbrance_unique;
+ALTER TABLE ${myuniversity}_${mymodule}."transaction" ADD CONSTRAINT transaction_encumbrance_unique UNIQUE USING INDEX transaction_encumbrance_idx_unique;
+

--- a/src/main/resources/templates/db_scripts/transactions.sql
+++ b/src/main/resources/templates/db_scripts/transactions.sql
@@ -1,6 +1,3 @@
 DROP TRIGGER IF EXISTS recalculate_totals on ${myuniversity}_${mymodule}."transaction";
 DROP FUNCTION IF EXISTS ${myuniversity}_${mymodule}.recalculate_totals();
 
-ALTER TABLE ${myuniversity}_${mymodule}."transaction" DROP CONSTRAINT IF EXISTS transaction_encumbrance_unique;
-ALTER TABLE ${myuniversity}_${mymodule}."transaction" ADD CONSTRAINT transaction_encumbrance_unique UNIQUE USING INDEX transaction_encumbrance_idx_unique;
-


### PR DESCRIPTION
## Purpose
Need to skip **transaction_encumbrance_idx_unique** unique index for 'transaction' table while running rollover

## Approach

- `ON CONFLICT (id) DO NOTHING` replaced with 
`WHERE NOT EXISTS (
     SELECT 1
     FROM ${myuniversity}_${mymodule}.transaction tr
     WHERE tr.id = t.id
)`
- We can't use **ON CONFLICT ON CONSTRAINT _constraint name_** because we refer to partial unique index. To resolve it was used index expression.

#### TODOS and Open Questions
Probably we need to use new PostgreSQL MERGE command to upsert these modified lines more elegant. Merge command is available from 16 version of PG: https://www.postgresql.org/docs/16/sql-merge.html

## Learning
[MODFISTO-461](https://folio-org.atlassian.net/browse/MODFISTO-461)

## Pre-Merge Checklist:
Before merging this PR, please go through the following list and take appropriate actions.

- Does this PR meet or exceed the expected quality standards?
  - [ ] Code coverage on new code is 80% or greater
  - [ ] Duplications on new code is 3% or less
  - [ ] There are no major code smells or security issues
- Does this introduce breaking changes?
  - [ ] Were any API paths or methods changed, added or removed?
  - [ ] Were there any schema changes?
  - [ ] Did any of the interface versions change?
  - [ ] Were permissions changed, added or removed?
  - [ ] Are there new interface dependencies?
  - [ ] There are no breaking changes in this PR.

If there are breaking changes, please **STOP** and consider the following:

- What other modules will these changes impact?
- Do JIRAs exist to update the impacted modules?
  - [ ] If not, please create them
  - [ ] Do they contain the appropriate level of detail?  Which endpoints/schemas changed, etc.
  - [ ] Do they have all the appropriate links to blocked/related issues?
- Are the JIRAs under active development?
  - [ ] If not, contact the project's PO and make sure they're aware of the urgency.
- Do PRs exist for these changes?
  - [ ] If so, have they been approved?
- Did you modify code to call some additional endpoints?
  - [ ] If so, do you check that necessary module permission added in ModuleDescriptor-template.yaml file?

Ideally, all the PRs involved in breaking changes would be merged on the same day
to avoid breaking the folio-testing environment.
Communication is paramount if that is to be achieved,
especially as the number of inter-module and inter-team dependencies increase.

While it's helpful for reviewers to help identify potential problems,
ensuring that it's safe to merge is ultimately the responsibility of the PR assignee.
