### PR TITLE
[MODFIN-352] Allow transaction processing for planned budgets + new amount validation

### DIFF
--- a/src/main/java/org/folio/rest/util/ErrorCodes.java
+++ b/src/main/java/org/folio/rest/util/ErrorCodes.java
@@ -15,7 +15,8 @@ public enum ErrorCodes {
     "Could not find the budget for the encumbrance. The encumbrance fund id is probably not matching the fund id in the invoice line."),
   BUDGET_IS_INACTIVE("budgetIsInactive", "Cannot create transaction from the not active budget {0}"),
   BUDGET_RESTRICTED_EXPENDITURES_ERROR("budgetRestrictedExpendituresError", "Expenditure restriction does not allow this operation"),
-  BUDGET_RESTRICTED_ENCUMBRANCE_ERROR("budgetRestrictedEncumbranceError", "Encumbrance restriction does not allow this operation");
+  BUDGET_RESTRICTED_ENCUMBRANCE_ERROR("budgetRestrictedEncumbranceError", "Encumbrance restriction does not allow this operation"),
+  PAYMENT_OR_CREDIT_HAS_NEGATIVE_AMOUNT("paymentOrCreditHasNegativeAmount", "A payment or credit has a negative amount");
   private final String code;
   private final String description;
 

--- a/src/main/java/org/folio/service/transactions/batch/BatchTransactionChecks.java
+++ b/src/main/java/org/folio/service/transactions/batch/BatchTransactionChecks.java
@@ -73,7 +73,7 @@ public class BatchTransactionChecks {
   public static void checkBudgetsAreActive(BatchTransactionHolder holder) {
     holder.getBudgets().forEach(budget -> {
       if (!List.of(ACTIVE, PLANNED).contains(budget.getBudgetStatus())) {
-        throw new HttpException(400, String.format("Cannot process transactions because of an inactive budget for fund %s",
+        throw new HttpException(400, String.format("Cannot process transactions because a budget is not active or planned, fundId=%s",
           holder.getFundCodeForBudget(budget)));
       }
     });

--- a/src/main/java/org/folio/service/transactions/batch/BatchTransactionChecks.java
+++ b/src/main/java/org/folio/service/transactions/batch/BatchTransactionChecks.java
@@ -273,8 +273,7 @@ public class BatchTransactionChecks {
       .toList();
     for (Transaction tr : newPaymentsAndCredits) {
       if (tr.getAmount() < 0) {
-        List<Parameter> parameters = new ArrayList<>();
-        parameters.add(new Parameter().withKey("id").withValue(tr.getId()));
+        List<Parameter> parameters = singletonList(new Parameter().withKey("id").withValue(tr.getId()));
         Error error = PAYMENT_OR_CREDIT_HAS_NEGATIVE_AMOUNT.toError().withParameters(parameters);
         throw new HttpException(422, error);
       }


### PR DESCRIPTION
## Purpose
[MODFIN-352](https://folio-org.atlassian.net/browse/MODFIN-352) - Remove the old transaction API

## Approach
- Allow transaction processing for planned budgets (to create new budgets with an allocation)
- Check new payments and credits have a positive amount (check migrated from the old mod-finance transaction API)

[related mod-finance PR](https://github.com/folio-org/mod-finance/pull/245)
[related integration tests PR](https://github.com/folio-org/folio-integration-tests/pull/1320)

## Pre-Merge Checklist:
Before merging this PR, please go through the following list and take appropriate actions.

- Does this PR meet or exceed the expected quality standards?
  - [ ] Code coverage on new code is 80% or greater
  - [ ] Duplications on new code is 3% or less
  - [ ] There are no major code smells or security issues
- Does this introduce breaking changes?
  - [ ] Were any API paths or methods changed, added or removed?
  - [ ] Were there any schema changes?
  - [ ] Did any of the interface versions change?
  - [ ] Were permissions changed, added or removed?
  - [ ] Are there new interface dependencies?
  - [ ] There are no breaking changes in this PR.

If there are breaking changes, please **STOP** and consider the following:

- What other modules will these changes impact?
- Do JIRAs exist to update the impacted modules?
  - [ ] If not, please create them
  - [ ] Do they contain the appropriate level of detail?  Which endpoints/schemas changed, etc.
  - [ ] Do they have all the appropriate links to blocked/related issues?
- Are the JIRAs under active development?
  - [ ] If not, contact the project's PO and make sure they're aware of the urgency.
- Do PRs exist for these changes?
  - [ ] If so, have they been approved?
- Did you modify code to call some additional endpoints?
  - [ ] If so, do you check that necessary module permission added in ModuleDescriptor-template.yaml file?

Ideally, all the PRs involved in breaking changes would be merged on the same day
to avoid breaking the folio-testing environment.
Communication is paramount if that is to be achieved,
especially as the number of inter-module and inter-team dependencies increase.

While it's helpful for reviewers to help identify potential problems,
ensuring that it's safe to merge is ultimately the responsibility of the PR assignee.
