### PR TITLE
[MODFISTO-460] Don't create an allocation for a closed fund

### DIFF
--- a/src/main/resources/data/transactions/allocations-8.4.0/all_allocations.json
+++ b/src/main/resources/data/transactions/allocations-8.4.0/all_allocations.json
@@ -31,16 +31,6 @@
       "transactionType": "Allocation"
     },
     {
-      "id": "65eab5a6-016f-468d-8397-0c90e3dc2ca0",
-      "amount": 12230.80,
-      "currency": "USD",
-      "fiscalYearId": "7a4c4d30-3b63-4102-8e2d-3ee5792d7d02",
-      "source": "User",
-      "sourceFiscalYearId": "7a4c4d30-3b63-4102-8e2d-3ee5792d7d02",
-      "toFundId": "67cd0046-e4f1-4e4f-9024-adf0b0039d09",
-      "transactionType": "Allocation"
-    },
-    {
       "id": "33c942ef-144d-4b3b-b8dc-f2695c57d8da",
       "amount": 201000.00,
       "currency": "USD",


### PR DESCRIPTION
## Purpose
Currently the data initialization from samples fails with:
> org.folio.rest.exception.HttpException: Cannot process transactions because a budget is not active or planned

This is because we try to create an allocation for a closed fund.

## Approach
Removed the allocation for the closed fund.

## Pre-Merge Checklist:
Before merging this PR, please go through the following list and take appropriate actions.

- Does this PR meet or exceed the expected quality standards?
  - [ ] Code coverage on new code is 80% or greater
  - [ ] Duplications on new code is 3% or less
  - [ ] There are no major code smells or security issues
- Does this introduce breaking changes?
  - [ ] Were any API paths or methods changed, added or removed?
  - [ ] Were there any schema changes?
  - [ ] Did any of the interface versions change?
  - [ ] Were permissions changed, added or removed?
  - [ ] Are there new interface dependencies?
  - [ ] There are no breaking changes in this PR.

If there are breaking changes, please **STOP** and consider the following:

- What other modules will these changes impact?
- Do JIRAs exist to update the impacted modules?
  - [ ] If not, please create them
  - [ ] Do they contain the appropriate level of detail?  Which endpoints/schemas changed, etc.
  - [ ] Do they have all the appropriate links to blocked/related issues?
- Are the JIRAs under active development?
  - [ ] If not, contact the project's PO and make sure they're aware of the urgency.
- Do PRs exist for these changes?
  - [ ] If so, have they been approved?
- Did you modify code to call some additional endpoints?
  - [ ] If so, do you check that necessary module permission added in ModuleDescriptor-template.yaml file?

Ideally, all the PRs involved in breaking changes would be merged on the same day
to avoid breaking the folio-testing environment.
Communication is paramount if that is to be achieved,
especially as the number of inter-module and inter-team dependencies increase.

While it's helpful for reviewers to help identify potential problems,
ensuring that it's safe to merge is ultimately the responsibility of the PR assignee.
