### PR TITLE
[MODFISTO-466] New transactionType indices

### DIFF
--- a/src/main/java/org/folio/service/budget/BudgetService.java
+++ b/src/main/java/org/folio/service/budget/BudgetService.java
@@ -139,7 +139,7 @@ public class BudgetService {
 
     String sql ="DELETE FROM "+ getFullTableName(conn.getTenantId(), TRANSACTIONS_TABLE)
       + " WHERE  (fromFundId = '" + budget.getFundId() + "' OR toFundId = '" + budget.getFundId() + "')"
-      + " AND fiscalYearId = '" + budget.getFiscalYearId() + "' AND lower(f_unaccent(jsonb->>'transactionType'::text)) = 'allocation'";
+      + " AND fiscalYearId = '" + budget.getFiscalYearId() + "' AND jsonb->>'transactionType' = 'Allocation'";
 
     return conn.execute(sql)
       .onSuccess(ecList -> logger.info("deleteAllocationTransactions:: Allocation transaction for budget with id {} successfully deleted",
@@ -155,8 +155,8 @@ public class BudgetService {
     String sql ="SELECT jsonb FROM " + getFullTableName(conn.getTenantId(), TRANSACTIONS_TABLE)
       + " WHERE fiscalYearId = '" + budget.getFiscalYearId() + "'"
       + " AND (fromFundId = '" + budget.getFundId() + "' OR toFundId = '" + budget.getFundId() + "')"
-      + " AND (lower(f_unaccent(jsonb->>'transactionType'::text)) <> 'allocation'"
-      + " OR (lower(f_unaccent(jsonb->>'transactionType'::text)) = 'allocation' AND toFundId IS NOT NULL AND fromFundId IS NOT NULL))";
+      + " AND (jsonb->>'transactionType' <> 'Allocation'"
+      + " OR (jsonb->>'transactionType' = 'Allocation' AND toFundId IS NOT NULL AND fromFundId IS NOT NULL))";
 
     return conn.execute(sql)
       .map(rowSet -> {

--- a/src/main/resources/templates/db_scripts/budget_encumbrances_rollover.sql
+++ b/src/main/resources/templates/db_scripts/budget_encumbrances_rollover.sql
@@ -362,7 +362,7 @@ CREATE OR REPLACE FUNCTION ${myuniversity}_${mymodule}.rollover_order(_order_id 
                         (jsonb ->> 'expenseClassId'::text),
                         (jsonb ->> 'fiscalYearId'::text)
                     ]))))
-                WHERE ((jsonb ->> 'transactionType'::text) = 'Encumbrance'::text) DO NOTHING;
+                WHERE (jsonb ->> 'transactionType' = 'Encumbrance') DO NOTHING;
             END IF;
         END IF;
 
@@ -701,7 +701,7 @@ CREATE OR REPLACE FUNCTION ${myuniversity}_${mymodule}.budget_encumbrances_rollo
                     (jsonb ->> 'expenseClassId'::text),
                     (jsonb ->> 'fiscalYearId'::text)
                 ]))))
-            WHERE ((jsonb ->> 'transactionType'::text) = 'Encumbrance'::text) DO NOTHING;
+            WHERE (jsonb ->> 'transactionType' = 'Encumbrance') DO NOTHING;
         END IF;
 
         DROP TABLE IF EXISTS tmp_transaction;

--- a/src/main/resources/templates/db_scripts/migration/simple_transaction_type_index.sql
+++ b/src/main/resources/templates/db_scripts/migration/simple_transaction_type_index.sql
@@ -1,0 +1,1 @@
+CREATE INDEX IF NOT EXISTS transaction_transactiontype_simple_idx ON ${myuniversity}_${mymodule}.transaction USING btree ((jsonb->>'transactionType'));

--- a/src/main/resources/templates/db_scripts/schema.json
+++ b/src/main/resources/templates/db_scripts/schema.json
@@ -90,6 +90,11 @@
       "run": "after",
       "snippetPath": "migration/transform_location_ids_array.sql",
       "fromModuleVersion": "mod-finance-storage-8.7.0"
+    },
+    {
+      "run": "after",
+      "snippetPath": "migration/simple_transaction_type_index.sql",
+      "fromModuleVersion": "mod-finance-storage-8.7.0"
     }
   ],
   "tables": [
@@ -373,19 +378,19 @@
           "fieldName": "encumbrance",
           "multiFieldNames": "amount, fromFundId, encumbrance.sourcePurchaseOrderId, encumbrance.sourcePoLineId, encumbrance.initialAmountEncumbered, encumbrance.status, expenseClassId, fiscalYearId",
           "tOps": "ADD",
-          "whereClause": "WHERE (jsonb->>'transactionType')::text = 'Encumbrance'"
+          "whereClause": "WHERE jsonb->>'transactionType' = 'Encumbrance'"
         },
         {
           "fieldName": "payment",
           "multiFieldNames": "amount, fromFundId, sourceInvoiceId, sourceInvoiceLineId, transactionType, expenseClassId",
           "tOps": "ADD",
-          "whereClause": "WHERE (jsonb->>'transactionType')::text = 'Payment' OR (jsonb->>'transactionType')::text = 'Pending payment'"
+          "whereClause": "WHERE jsonb->>'transactionType' = 'Payment' OR jsonb->>'transactionType' = 'Pending payment'"
         },
         {
           "fieldName": "credit",
           "multiFieldNames": "amount, toFundId, sourceInvoiceId, sourceInvoiceLineId, transactionType, expenseClassId",
           "tOps": "ADD",
-          "whereClause": "WHERE (jsonb->>'transactionType')::text = 'Credit'"
+          "whereClause": "WHERE jsonb->>'transactionType' = 'Credit'"
         }
       ],
       "foreignKeys": [
@@ -416,6 +421,12 @@
       ],
       "index": [
         {
+          "fieldName": "transactionType",
+          "tOps": "ADD",
+          "removeAccents": false,
+          "caseSensitive": true
+        },
+        {
           "fieldName": "encumbrance.sourcePurchaseOrderId",
           "tOps": "ADD"
         },
@@ -433,9 +444,7 @@
         },
         {
           "fieldName": "transactionType",
-          "tOps": "ADD",
-          "caseSensitive": false,
-          "removeAccents": true
+          "tOps": "DELETE"
         }
       ]
     },

--- a/src/main/resources/templates/db_scripts/transactions.sql
+++ b/src/main/resources/templates/db_scripts/transactions.sql
@@ -1,3 +1,3 @@
 DROP TRIGGER IF EXISTS recalculate_totals on ${myuniversity}_${mymodule}."transaction";
 DROP FUNCTION IF EXISTS ${myuniversity}_${mymodule}.recalculate_totals();
-
+CREATE INDEX IF NOT EXISTS transaction_transactiontype_simple_idx ON ${myuniversity}_${mymodule}.transaction USING btree ((jsonb->>'transactionType'));


### PR DESCRIPTION
## Purpose
[MODFISTO-466](https://folio-org.atlassian.net/browse/MODFISTO-466) - Make usage of an DB index for transaction type in the rollover script

## Approach
There was a [slack discussion](https://folio-project.slack.com/archives/C210RP0T1/p1714137089098889) about this. There is no way with RMB to use a simple index for enumerated fields. To keep our code simple I had to create 2 indices for transactionType.
- Removed the old gin index
- Added a b-tree index in the schema, created by RMB; it is case sensitive and preserves accents; implementation uses a left truncation which matches SQL generated by CQL queries
- Added a custom b-tree index which is not using left truncation; this lets us use transactionType directly in the FYRO script
- Checked that the indices are actually used:
  - For SQL:
  `EXPLAIN SELECT jsonb,id FROM diku_mod_finance_storage.transaction WHERE jsonb->>'transactionType' = 'Allocation'`
  `
Index Scan using transaction_transactiontype_simple_idx on transaction  (cost=0.28..9.73 rows=14 width=944)
  Index Cond: ((jsonb ->> 'transactionType'::text) = 'Allocation'::text)
`
  - For CQL:
  `EXPLAIN SELECT jsonb,id FROM diku_mod_finance_storage.transaction WHERE CASE WHEN length('Allocation') <= 600 THEN left(transaction.jsonb->>'transactionType',600) LIKE 'Allocation' ELSE left(transaction.jsonb->>'transactionType',600) LIKE left('Allocation',600) AND transaction.jsonb->>'transactionType' LIKE 'Allocation' END`
  `
Index Scan using transaction_transactiontype_idx on transaction  (cost=0.15..72.75 rows=171 width=872)
  Index Cond: ("left"((jsonb ->> 'transactionType'::text), 600) = 'Allocation'::text)
  Filter: ("left"((jsonb ->> 'transactionType'::text), 600) ~~ 'Allocation'::text)
`

Related integration tests PR

## Pre-Merge Checklist:
Before merging this PR, please go through the following list and take appropriate actions.

- Does this PR meet or exceed the expected quality standards?
  - [ ] Code coverage on new code is 80% or greater
  - [ ] Duplications on new code is 3% or less
  - [ ] There are no major code smells or security issues
- Does this introduce breaking changes?
  - [ ] Were any API paths or methods changed, added or removed?
  - [ ] Were there any schema changes?
  - [ ] Did any of the interface versions change?
  - [ ] Were permissions changed, added or removed?
  - [ ] Are there new interface dependencies?
  - [ ] There are no breaking changes in this PR.

If there are breaking changes, please **STOP** and consider the following:

- What other modules will these changes impact?
- Do JIRAs exist to update the impacted modules?
  - [ ] If not, please create them
  - [ ] Do they contain the appropriate level of detail?  Which endpoints/schemas changed, etc.
  - [ ] Do they have all the appropriate links to blocked/related issues?
- Are the JIRAs under active development?
  - [ ] If not, contact the project's PO and make sure they're aware of the urgency.
- Do PRs exist for these changes?
  - [ ] If so, have they been approved?
- Did you modify code to call some additional endpoints?
  - [ ] If so, do you check that necessary module permission added in ModuleDescriptor-template.yaml file?

Ideally, all the PRs involved in breaking changes would be merged on the same day
to avoid breaking the folio-testing environment.
Communication is paramount if that is to be achieved,
especially as the number of inter-module and inter-team dependencies increase.

While it's helpful for reviewers to help identify potential problems,
ensuring that it's safe to merge is ultimately the responsibility of the PR assignee.
