### PR TITLE
[MODFISTO-488] Fixed encumbrance changes after cancelling a payment or credit

### DIFF
--- a/src/main/java/org/folio/service/transactions/batch/BatchPaymentCreditService.java
+++ b/src/main/java/org/folio/service/transactions/batch/BatchPaymentCreditService.java
@@ -76,10 +76,12 @@ public class BatchPaymentCreditService extends AbstractBatchTransactionService {
     double amount = encumbrance.getAmount();
     if (transaction.getTransactionType() == PAYMENT) {
       expended = subtractMoney(expended, transaction.getAmount(), currency);
-      amount = sumMoney(amount, transaction.getAmount(), currency);
+      if (encumbrance.getEncumbrance().getStatus() == Encumbrance.Status.UNRELEASED) {
+        amount = sumMoney(amount, transaction.getAmount(), currency);
+      }
     } else {
       credited = subtractMoney(credited, transaction.getAmount(), currency);
-      if (Encumbrance.Status.RELEASED != encumbrance.getEncumbrance().getStatus()) {
+      if (encumbrance.getEncumbrance().getStatus() == Encumbrance.Status.UNRELEASED) {
         amount = subtractMoney(amount, transaction.getAmount(), currency);
       }
     }

--- a/src/main/java/org/folio/service/transactions/batch/BatchPendingPaymentService.java
+++ b/src/main/java/org/folio/service/transactions/batch/BatchPendingPaymentService.java
@@ -15,6 +15,7 @@ import javax.money.CurrencyUnit;
 import javax.money.Monetary;
 
 import org.folio.rest.jaxrs.model.Budget;
+import org.folio.rest.jaxrs.model.Encumbrance;
 import org.folio.rest.jaxrs.model.Transaction;
 import org.folio.rest.jaxrs.model.Transaction.TransactionType;
 
@@ -80,7 +81,7 @@ public class BatchPendingPaymentService extends AbstractBatchTransactionService 
   }
 
   private void updateEncumbranceToCancelTransaction(Transaction encumbrance, double amount, CurrencyUnit currency) {
-    if (RELEASED != encumbrance.getEncumbrance().getStatus()) {
+    if (encumbrance.getEncumbrance().getStatus() == Encumbrance.Status.UNRELEASED) {
       encumbrance.setAmount(sumMoney(encumbrance.getAmount(), amount, currency));
     }
     encumbrance.getEncumbrance().setAmountAwaitingPayment(subtractMoney(

--- a/src/test/java/org/folio/service/transactions/PaymentCreditTest.java
+++ b/src/test/java/org/folio/service/transactions/PaymentCreditTest.java
@@ -11,6 +11,8 @@ import org.folio.rest.jaxrs.model.Metadata;
 import org.folio.rest.jaxrs.model.Transaction;
 import org.folio.rest.persist.Criteria.Criterion;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.EnumSource;
 import org.mockito.ArgumentCaptor;
 
 import java.util.Collections;
@@ -21,6 +23,7 @@ import static io.vertx.core.Future.succeededFuture;
 import static org.folio.dao.transactions.BatchTransactionDAO.TRANSACTIONS_TABLE;
 import static org.folio.rest.impl.BudgetAPI.BUDGET_TABLE;
 import static org.folio.rest.jaxrs.model.Encumbrance.Status.RELEASED;
+import static org.folio.rest.jaxrs.model.Encumbrance.Status.UNRELEASED;
 import static org.folio.rest.jaxrs.model.Transaction.Source.PO_LINE;
 import static org.folio.rest.jaxrs.model.Transaction.TransactionType.CREDIT;
 import static org.folio.rest.jaxrs.model.Transaction.TransactionType.ENCUMBRANCE;
@@ -507,8 +510,9 @@ public class PaymentCreditTest extends BatchTransactionServiceTestBase {
       });
   }
 
-  @Test
-  void testCancelPaymentWithLinkedEncumbrance(VertxTestContext testContext) {
+  @ParameterizedTest
+  @EnumSource(Encumbrance.Status.class)
+  void testCancelPaymentWithLinkedEncumbrance(Encumbrance.Status encumbranceStatus, VertxTestContext testContext) {
     String paymentId = UUID.randomUUID().toString();
     String encumbranceId = UUID.randomUUID().toString();
     String invoiceId = UUID.randomUUID().toString();
@@ -540,7 +544,7 @@ public class PaymentCreditTest extends BatchTransactionServiceTestBase {
       .withFiscalYearId(fiscalYearId)
       .withSource(PO_LINE)
       .withEncumbrance(new Encumbrance()
-        .withStatus(RELEASED)
+        .withStatus(encumbranceStatus)
         .withAmountAwaitingPayment(0d)
         .withAmountExpended(5d)
         .withInitialAmountEncumbered(5d))
@@ -587,9 +591,9 @@ public class PaymentCreditTest extends BatchTransactionServiceTestBase {
           assertThat(updateTableNames.get(0), equalTo(TRANSACTIONS_TABLE));
           Transaction savedEncumbrance = (Transaction)(updateEntities.get(0).get(1));
           assertThat(savedEncumbrance.getTransactionType(), equalTo(ENCUMBRANCE));
-          assertThat(savedEncumbrance.getEncumbrance().getStatus(), equalTo(RELEASED));
+          assertThat(savedEncumbrance.getEncumbrance().getStatus(), equalTo(encumbranceStatus));
           assertNotNull(savedEncumbrance.getMetadata().getUpdatedDate());
-          assertThat(savedEncumbrance.getAmount(), equalTo(0d));
+          assertThat(savedEncumbrance.getAmount(), equalTo(encumbranceStatus == UNRELEASED ? 5d : 0d));
           assertThat(savedEncumbrance.getEncumbrance().getInitialAmountEncumbered(), equalTo(5d));
           assertThat(savedEncumbrance.getEncumbrance().getAmountAwaitingPayment(), equalTo(0d));
           assertThat(savedEncumbrance.getEncumbrance().getAmountExpended(), equalTo(0d));
@@ -598,7 +602,7 @@ public class PaymentCreditTest extends BatchTransactionServiceTestBase {
           assertThat(updateTableNames.get(1), equalTo(BUDGET_TABLE));
           Budget savedBudget = (Budget)(updateEntities.get(1).get(0));
           assertNotNull(savedBudget.getMetadata().getUpdatedDate());
-          assertThat(savedBudget.getEncumbered(), equalTo(0d));
+          assertThat(savedBudget.getEncumbered(), equalTo(encumbranceStatus == UNRELEASED ? 5d : 0d));
           assertThat(savedBudget.getAwaitingPayment(), equalTo(0d));
           assertThat(savedBudget.getExpenditures(), equalTo(0d));
         });
@@ -606,8 +610,9 @@ public class PaymentCreditTest extends BatchTransactionServiceTestBase {
       });
   }
 
-  @Test
-  void testCancelCreditWithLinkedEncumbrance(VertxTestContext testContext) {
+  @ParameterizedTest
+  @EnumSource(Encumbrance.Status.class)
+  void testCancelCreditWithLinkedEncumbrance(Encumbrance.Status encumbranceStatus, VertxTestContext testContext) {
     String creditId = UUID.randomUUID().toString();
     String encumbranceId = UUID.randomUUID().toString();
     String invoiceId = UUID.randomUUID().toString();
@@ -635,13 +640,13 @@ public class PaymentCreditTest extends BatchTransactionServiceTestBase {
       .withTransactionType(ENCUMBRANCE)
       .withCurrency("USD")
       .withFromFundId(fundId)
-      .withAmount(0d)
+      .withAmount(encumbranceStatus == UNRELEASED ? 10d : 0d)
       .withFiscalYearId(fiscalYearId)
       .withSource(PO_LINE)
       .withEncumbrance(new Encumbrance()
-        .withStatus(RELEASED)
+        .withStatus(encumbranceStatus)
         .withAmountAwaitingPayment(0d)
-        .withAmountExpended(5d)
+        .withAmountExpended(0d)
         .withAmountCredited(5d)
         .withInitialAmountEncumbered(5d))
       .withMetadata(new Metadata());
@@ -649,7 +654,8 @@ public class PaymentCreditTest extends BatchTransactionServiceTestBase {
     Batch batch = new Batch();
     batch.getTransactionsToUpdate().add(newPayment);
 
-    setupFundBudgetLedger(fundId, fiscalYearId, 0d, 0d, 5d, 5d, false, false, false);
+    setupFundBudgetLedger(fundId, fiscalYearId, encumbranceStatus == UNRELEASED ? 10d : 0d, 0d,
+      5d, 0d, false, false, false);
 
     Criterion paymentCriterion = createCriterionByIds(List.of(creditId));
     doReturn(succeededFuture(createResults(List.of(existingCredit))))
@@ -687,21 +693,21 @@ public class PaymentCreditTest extends BatchTransactionServiceTestBase {
           assertThat(updateTableNames.get(0), equalTo(TRANSACTIONS_TABLE));
           Transaction savedEncumbrance = (Transaction)(updateEntities.get(0).get(1));
           assertThat(savedEncumbrance.getTransactionType(), equalTo(ENCUMBRANCE));
-          assertThat(savedEncumbrance.getEncumbrance().getStatus(), equalTo(RELEASED));
+          assertThat(savedEncumbrance.getEncumbrance().getStatus(), equalTo(encumbranceStatus));
           assertNotNull(savedEncumbrance.getMetadata().getUpdatedDate());
-          assertThat(savedEncumbrance.getAmount(), equalTo(0d));
+          assertThat(savedEncumbrance.getAmount(), equalTo(encumbranceStatus == UNRELEASED ? 5d : 0d));
           assertThat(savedEncumbrance.getEncumbrance().getInitialAmountEncumbered(), equalTo(5d));
           assertThat(savedEncumbrance.getEncumbrance().getAmountAwaitingPayment(), equalTo(0d));
-          assertThat(savedEncumbrance.getEncumbrance().getAmountExpended(), equalTo(5d));
+          assertThat(savedEncumbrance.getEncumbrance().getAmountExpended(), equalTo(0d));
           assertThat(savedEncumbrance.getEncumbrance().getAmountCredited(), equalTo(0d));
 
           // Verify budget update
           assertThat(updateTableNames.get(1), equalTo(BUDGET_TABLE));
           Budget savedBudget = (Budget)(updateEntities.get(1).get(0));
           assertNotNull(savedBudget.getMetadata().getUpdatedDate());
-          assertThat(savedBudget.getEncumbered(), equalTo(0d));
+          assertThat(savedBudget.getEncumbered(), equalTo(encumbranceStatus == UNRELEASED ? 5d : 0d));
           assertThat(savedBudget.getAwaitingPayment(), equalTo(0d));
-          assertThat(savedBudget.getExpenditures(), equalTo(5d));
+          assertThat(savedBudget.getExpenditures(), equalTo(0d));
           assertThat(savedBudget.getCredits(), equalTo(0d));
         });
         testContext.completeNow();

--- a/src/test/java/org/folio/service/transactions/PaymentCreditTest.java
+++ b/src/test/java/org/folio/service/transactions/PaymentCreditTest.java
@@ -589,7 +589,8 @@ public class PaymentCreditTest extends BatchTransactionServiceTestBase {
           assertThat(savedEncumbrance.getTransactionType(), equalTo(ENCUMBRANCE));
           assertThat(savedEncumbrance.getEncumbrance().getStatus(), equalTo(RELEASED));
           assertNotNull(savedEncumbrance.getMetadata().getUpdatedDate());
-          assertThat(savedEncumbrance.getAmount(), equalTo(5d));
+          assertThat(savedEncumbrance.getAmount(), equalTo(0d));
+          assertThat(savedEncumbrance.getEncumbrance().getInitialAmountEncumbered(), equalTo(5d));
           assertThat(savedEncumbrance.getEncumbrance().getAmountAwaitingPayment(), equalTo(0d));
           assertThat(savedEncumbrance.getEncumbrance().getAmountExpended(), equalTo(0d));
 
@@ -689,6 +690,7 @@ public class PaymentCreditTest extends BatchTransactionServiceTestBase {
           assertThat(savedEncumbrance.getEncumbrance().getStatus(), equalTo(RELEASED));
           assertNotNull(savedEncumbrance.getMetadata().getUpdatedDate());
           assertThat(savedEncumbrance.getAmount(), equalTo(0d));
+          assertThat(savedEncumbrance.getEncumbrance().getInitialAmountEncumbered(), equalTo(5d));
           assertThat(savedEncumbrance.getEncumbrance().getAmountAwaitingPayment(), equalTo(0d));
           assertThat(savedEncumbrance.getEncumbrance().getAmountExpended(), equalTo(5d));
           assertThat(savedEncumbrance.getEncumbrance().getAmountCredited(), equalTo(0d));

--- a/src/test/java/org/folio/service/transactions/PendingPaymentTest.java
+++ b/src/test/java/org/folio/service/transactions/PendingPaymentTest.java
@@ -12,6 +12,7 @@ import org.folio.rest.jaxrs.model.Transaction;
 import org.folio.rest.persist.Criteria.Criterion;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.EnumSource;
 import org.junit.jupiter.params.provider.ValueSource;
 import org.mockito.ArgumentCaptor;
 
@@ -263,8 +264,9 @@ public class PendingPaymentTest extends BatchTransactionServiceTestBase {
       });
   }
 
-  @Test
-  void testCancelPendingPaymentWithLinkedEncumbrance(VertxTestContext testContext) {
+  @ParameterizedTest
+  @EnumSource(Encumbrance.Status.class)
+  void testCancelPendingPaymentWithLinkedEncumbrance(Encumbrance.Status encumbranceStatus, VertxTestContext testContext) {
     String pendingPaymentId = UUID.randomUUID().toString();
     String encumbranceId = UUID.randomUUID().toString();
     String invoiceId = UUID.randomUUID().toString();
@@ -298,7 +300,7 @@ public class PendingPaymentTest extends BatchTransactionServiceTestBase {
       .withFiscalYearId(fiscalYearId)
       .withSource(PO_LINE)
       .withEncumbrance(new Encumbrance()
-        .withStatus(RELEASED)
+        .withStatus(encumbranceStatus)
         .withAmountAwaitingPayment(5d)
         .withInitialAmountEncumbered(5d))
       .withMetadata(new Metadata());
@@ -340,16 +342,16 @@ public class PendingPaymentTest extends BatchTransactionServiceTestBase {
           // Verify encumbrance update
           Transaction savedEncumbrance = (Transaction)(entities.get(0).get(1));
           assertThat(savedEncumbrance.getTransactionType(), equalTo(ENCUMBRANCE));
-          assertThat(savedEncumbrance.getEncumbrance().getStatus(), equalTo(RELEASED));
+          assertThat(savedEncumbrance.getEncumbrance().getStatus(), equalTo(encumbranceStatus));
           assertNotNull(savedEncumbrance.getMetadata().getUpdatedDate());
-          assertThat(savedEncumbrance.getAmount(), equalTo(0d));
+          assertThat(savedEncumbrance.getAmount(), equalTo(encumbranceStatus == UNRELEASED ? 5d : 0d));
           assertThat(savedEncumbrance.getEncumbrance().getAmountAwaitingPayment(), equalTo(0d));
 
           // Verify budget update
           assertThat(tableNames.get(1), equalTo(BUDGET_TABLE));
           Budget savedBudget = (Budget)(entities.get(1).get(0));
           assertNotNull(savedBudget.getMetadata().getUpdatedDate());
-          assertThat(savedBudget.getEncumbered(), equalTo(0d));
+          assertThat(savedBudget.getEncumbered(), equalTo(encumbranceStatus == UNRELEASED ? 5d : 0d));
           assertThat(savedBudget.getAwaitingPayment(), equalTo(0d));
         });
         testContext.completeNow();


### PR DESCRIPTION
## Purpose
[MODFISTO-488](https://folio-org.atlassian.net/browse/MODFISTO-488) - Wrong encumbrance when cancelling an invoice with an order that is not open

## Approach
- Fixed encumbrance calculations when cancelling a pending payment, payment or credit (see ticket).
- Fixed and improved unit tests
- Checked result with the UI

[Integration tests PR](https://github.com/folio-org/folio-integration-tests/pull/1419)

## Pre-Merge Checklist:
Before merging this PR, please go through the following list and take appropriate actions.

- Does this PR meet or exceed the expected quality standards?
  - [ ] Code coverage on new code is 80% or greater
  - [ ] Duplications on new code is 3% or less
  - [ ] There are no major code smells or security issues
- Does this introduce breaking changes?
  - [ ] Were any API paths or methods changed, added or removed?
  - [ ] Were there any schema changes?
  - [ ] Did any of the interface versions change?
  - [ ] Were permissions changed, added or removed?
  - [ ] Are there new interface dependencies?
  - [ ] There are no breaking changes in this PR.

If there are breaking changes, please **STOP** and consider the following:

- What other modules will these changes impact?
- Do JIRAs exist to update the impacted modules?
  - [ ] If not, please create them
  - [ ] Do they contain the appropriate level of detail?  Which endpoints/schemas changed, etc.
  - [ ] Do they have all the appropriate links to blocked/related issues?
- Are the JIRAs under active development?
  - [ ] If not, contact the project's PO and make sure they're aware of the urgency.
- Do PRs exist for these changes?
  - [ ] If so, have they been approved?
- Did you modify code to call some additional endpoints?
  - [ ] If so, do you check that necessary module permission added in ModuleDescriptor-template.yaml file?

Ideally, all the PRs involved in breaking changes would be merged on the same day
to avoid breaking the folio-testing environment.
Communication is paramount if that is to be achieved,
especially as the number of inter-module and inter-team dependencies increase.

While it's helpful for reviewers to help identify potential problems,
ensuring that it's safe to merge is ultimately the responsibility of the PR assignee.
