### PR TITLE
[MODFISTO-483] - Add credited field support to Rollover functionality

### DIFF
--- a/src/main/resources/templates/db_scripts/budget_encumbrances_rollover.sql
+++ b/src/main/resources/templates/db_scripts/budget_encumbrances_rollover.sql
@@ -485,7 +485,7 @@ CREATE OR REPLACE FUNCTION ${myuniversity}_${mymodule}.build_budget(_budget json
                 'awaitingPayment', 0,
                 'encumbered', 0,
                 'expenditures', 0,
-                "credits", 0,
+                "credits", 0
             );
 
         IF allowableEncumbrance is not null

--- a/src/main/resources/templates/db_scripts/budget_encumbrances_rollover.sql
+++ b/src/main/resources/templates/db_scripts/budget_encumbrances_rollover.sql
@@ -485,7 +485,7 @@ CREATE OR REPLACE FUNCTION ${myuniversity}_${mymodule}.build_budget(_budget json
                 'awaitingPayment', 0,
                 'encumbered', 0,
                 'expenditures', 0,
-                "credits", 0
+                'credits', 0
             );
 
         IF allowableEncumbrance is not null


### PR DESCRIPTION
https://folio-org.atlassian.net/browse/MODFISTO-483
## Approach
Updated budget_encumbrances_rollover.sql
- In calculate_planned_encumbrance_amount, replace jsonb->'encumbrance'->>'amountExpended' by (jsonb->'encumbrance'->>'amountExpended')::decimal - (jsonb->'encumbrance'->>'amountCredited')::decimal
- In rollover_order,  add 'amountCredited', 0, after 'amountExpended', 0,.
Add a credited variable to build_budget and set credited := (_budget->>'credits')::decimal;
- In later calculations, replace expended by expended - credited
Add the credits field to result_budget