### PR TITLE
[MODORDERS-1162]. Order line encumbrance link not updated when re-encumber is false and order type not rolled over

### DIFF
--- a/src/main/java/org/folio/service/rollover/LedgerRolloverService.java
+++ b/src/main/java/org/folio/service/rollover/LedgerRolloverService.java
@@ -150,7 +150,7 @@ public class LedgerRolloverService {
 
   private Future<Void> startOrdersRollover(LedgerFiscalYearRollover rollover, LedgerFiscalYearRolloverProgress progress,
       RequestContext requestContext, DBConn conn) {
-    if (LedgerFiscalYearRollover.RolloverType.PREVIEW.equals(rollover.getRolloverType()) || rollover.getEncumbrancesRollover().isEmpty()) {
+    if (LedgerFiscalYearRollover.RolloverType.PREVIEW.equals(rollover.getRolloverType())) {
       logger.info("startOrdersRollover:: Orders rollover skipped for Ledger {} and rollover type {}", rollover.getLedgerId(), rollover.getRolloverType());
       return rolloverProgressService.calculateAndUpdateOverallProgressStatus(progress.withOrdersRolloverStatus(SUCCESS), conn);
     }

--- a/src/test/java/org/folio/service/rollover/LedgerRolloverServiceTest.java
+++ b/src/test/java/org/folio/service/rollover/LedgerRolloverServiceTest.java
@@ -329,10 +329,11 @@ public class LedgerRolloverServiceTest {
       });
   }
 
+  // Adapted for a PREVIEW type due to the new requirements defined by MODORDERS-1171 and implemented by MODORDERS-1162
   @Test
   void shouldSkipOrderRollover(VertxTestContext testContext) {
     LedgerFiscalYearRollover rollover = new LedgerFiscalYearRollover().withId(UUID.randomUUID()
-      .toString());
+      .toString()).withRolloverType(LedgerFiscalYearRollover.RolloverType.PREVIEW);
     LedgerFiscalYearRolloverProgress initialProgress = getInitialProgress(rollover);
 
     when(rolloverProgressService.updateRolloverProgress(


### PR DESCRIPTION
## Purpose

- <https://folio-org.atlassian.net/browse/MODORDERS-1162>

## Approach

- Remove a condition set in by this PR: [MODFISTO-298](<https://github.com/folio-org/mod-finance-storage/blob/06c18e36947ce250d7384e23edc054360b3c48b8/src/main/java/org/folio/service/rollover/LedgerRolloverService.java#L132>)
- Update encumbrance statuses in `budget_encumbrances_rollover` stored function so that the rollover can occur without any enabled settings to output `Released` encumbrance transactions with amounts equal to 0

## Related issues

- <https://github.com/folio-org/mod-orders/pull/1022>
- <https://github.com/folio-org/folio-integration-tests/pull/1536>