### PR TITLE
[MODFISTO-499] Update libraries of dependant acq modules to the latest versions

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -21,31 +21,34 @@
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 
     <!--Dependency Properties-->
-    <vertx.version>4.5.4</vertx.version>
+    <vertx.version>4.5.10</vertx.version>
     <postgres.image>postgres:12-alpine</postgres.image>
-    <log4j.version>2.23.0</log4j.version>
-    <aspectj.version>1.9.21.1</aspectj.version>
+    <log4j.version>2.24.1</log4j.version>
+    <aspectj.version>1.9.22.1</aspectj.version>
     <java.version>17</java.version>
-    <jackson-bom.version>2.15.2</jackson-bom.version>
+    <jackson-bom.version>2.18.0</jackson-bom.version>
+
+    <!--Folio dependencies properties-->
+    <folio-module-descriptor-validator.version>1.0.0</folio-module-descriptor-validator.version>
     <folio-di-support.version>2.1.0</folio-di-support.version>
 
     <!--Maven plugin properties-->
     <aspectj-maven-plugin.version>1.14</aspectj-maven-plugin.version>
-    <exec-maven-plugin.version>3.2.0</exec-maven-plugin.version>
+    <exec-maven-plugin.version>3.4.1</exec-maven-plugin.version>
     <maven-resources-plugin.version>3.3.1</maven-resources-plugin.version>
-    <maven-compiler-plugin.version>3.12.1</maven-compiler-plugin.version>
+    <maven-compiler-plugin.version>3.13.0</maven-compiler-plugin.version>
     <maven-antrun-plugin.version>3.1.0</maven-antrun-plugin.version>
-    <maven-shade-plugin.version>3.5.2</maven-shade-plugin.version>
-    <maven-release-plugin.version>3.0.1</maven-release-plugin.version>
-    <maven-surefire-plugin.version>3.2.5</maven-surefire-plugin.version>
-    <build-helper-maven-plugin.version>3.5.0</build-helper-maven-plugin.version>
+    <maven-shade-plugin.version>3.6.0</maven-shade-plugin.version>
+    <maven-release-plugin.version>3.1.1</maven-release-plugin.version>
+    <maven-surefire-plugin.version>3.5.1</maven-surefire-plugin.version>
+    <build-helper-maven-plugin.version>3.6.0</build-helper-maven-plugin.version>
     <copy-rename-maven-plugin.version>1.0.1</copy-rename-maven-plugin.version>
 
     <!--Test Scope dependencies-->
     <jmockit.version>1.49</jmockit.version>
-    <testcontainers.version>1.19.6</testcontainers.version>
-    <junit.jupiter.version>5.10.0</junit.jupiter.version>
-    <rest-assured.version>5.4.0</rest-assured.version>
+    <testcontainers.version>1.20.2</testcontainers.version>
+    <junit.jupiter.version>5.11.2</junit.jupiter.version>
+    <rest-assured.version>5.5.0</rest-assured.version>
 
     <!--Sonar properties-->
     <sonar.test.exclusions>**/*Test.java</sonar.test.exclusions>
@@ -115,7 +118,7 @@
     <dependency>
       <groupId>org.javamoney</groupId>
       <artifactId>moneta</artifactId>
-      <version>1.4.2</version>
+      <version>1.4.4</version>
       <type>pom</type>
     </dependency>
     <dependency>
@@ -150,7 +153,7 @@
     <dependency>
       <groupId>org.mockito</groupId>
       <artifactId>mockito-core</artifactId>
-      <version>3.6.0</version>
+      <version>5.14.2</version>
       <scope>test</scope>
     </dependency>
     <dependency>
@@ -251,6 +254,18 @@
             <id>generate_interfaces</id>
             <goals>
               <goal>java</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
+      <plugin>
+        <groupId>org.folio</groupId>
+        <artifactId>folio-module-descriptor-validator</artifactId>
+        <version>${folio-module-descriptor-validator.version}</version>
+        <executions>
+          <execution>
+            <goals>
+              <goal>validate</goal>
             </goals>
           </execution>
         </executions>

--- a/pom.xml
+++ b/pom.xml
@@ -22,7 +22,7 @@
 
     <!--Dependency Properties-->
     <vertx.version>4.5.10</vertx.version>
-    <postgres.image>postgres:12-alpine</postgres.image>
+    <postgres.image>postgres:16-alpine</postgres.image>
     <log4j.version>2.24.1</log4j.version>
     <aspectj.version>1.9.22.1</aspectj.version>
     <java.version>17</java.version>

--- a/pom.xml
+++ b/pom.xml
@@ -17,7 +17,7 @@
     <ramlfiles_path>${basedir}/ramls</ramlfiles_path>
     <ramlfiles_util_path>${ramlfiles_path}/raml-util</ramlfiles_util_path>
     <ramlfiles_acq_models_path>${ramlfiles_path}/acq-models</ramlfiles_acq_models_path>
-    <raml-module-builder.version>35.3.0-SNAPSHOT</raml-module-builder.version>
+    <raml-module-builder.version>35.3.0</raml-module-builder.version>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 
     <!--Dependency Properties-->

--- a/pom.xml
+++ b/pom.xml
@@ -45,7 +45,6 @@
 
     <!--Test Scope dependencies-->
     <jmockit.version>1.49</jmockit.version>
-    <testcontainers.version>1.20.2</testcontainers.version>
     <junit.jupiter.version>5.11.2</junit.jupiter.version>
     <rest-assured.version>5.5.0</rest-assured.version>
 
@@ -133,15 +132,9 @@
       <scope>test</scope>
     </dependency>
     <dependency>
-      <groupId>org.testcontainers</groupId>
-      <artifactId>postgresql</artifactId>
-      <version>${testcontainers.version}</version>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
-      <groupId>org.testcontainers</groupId>
-      <artifactId>junit-jupiter</artifactId>
-      <version>${testcontainers.version}</version>
+      <groupId>org.awaitility</groupId>
+      <artifactId>awaitility</artifactId>
+      <version>4.2.2</version>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -22,7 +22,6 @@
 
     <!--Dependency Properties-->
     <vertx.version>4.5.10</vertx.version>
-    <postgres.image>postgres:16-alpine</postgres.image>
     <log4j.version>2.24.1</log4j.version>
     <aspectj.version>1.9.22.1</aspectj.version>
     <java.version>17</java.version>

--- a/src/test/java/org/folio/rest/impl/EntitiesCrudTest.java
+++ b/src/test/java/org/folio/rest/impl/EntitiesCrudTest.java
@@ -1,5 +1,6 @@
 package org.folio.rest.impl;
 
+import static org.awaitility.Awaitility.await;
 import static org.folio.rest.utils.TestEntities.BUDGET;
 import static org.folio.rest.utils.TestEntities.BUDGET_EXPENSE_CLASS;
 import static org.folio.rest.utils.TestEntities.EXPENSE_CLASS;
@@ -13,7 +14,6 @@ import static org.folio.rest.utils.TestEntities.LEDGER_FISCAL_YEAR_ROLLOVER;
 import static org.folio.rest.utils.TestEntities.LEDGER_FISCAL_YEAR_ROLLOVER_LOG;
 import static org.folio.rest.utils.TestEntities.LEDGER_FISCAL_YEAR_ROLLOVER_ERROR;
 import static org.folio.rest.utils.TestEntities.LEDGER_FISCAL_YEAR_ROLLOVER_PROGRESS;
-import static org.testcontainers.shaded.org.awaitility.Awaitility.await;
 
 import java.util.Objects;
 import java.util.concurrent.TimeUnit;


### PR DESCRIPTION
## Purpose
[[MODFISTO-499] Update libraries of dependant acq modules to the latest versions
](https://folio-org.atlassian.net/browse/MODFISTO-499)

## Approach
- Update versions
- Add module descriptor validator