### PR TITLE
[MODFISTO-511] - Fix sql migration by using json_build_object

### DIFF
--- a/src/main/resources/templates/db_scripts/migration/extract_credits_from_expenditures.sql
+++ b/src/main/resources/templates/db_scripts/migration/extract_credits_from_expenditures.sql
@@ -40,14 +40,11 @@ WITH aggregated_amounts AS (
 )
 UPDATE ${myuniversity}_${mymodule}.transaction AS encumbrance
 SET
-    jsonb = jsonb_set(
-        jsonb_set(
-            encumbrance.jsonb,
-            '{encumbrance,amountExpended}',
-            to_jsonb(aggregated_amounts.total_expended)
-        ),
-        '{encumbrance,amountCredited}',
-        to_jsonb(aggregated_amounts.total_credited)
+    jsonb = jsonb || jsonb_build_object(
+        'encumbrance', jsonb_build_object(
+            'amountExpended', to_jsonb(aggregated_amounts.total_expended),
+            'amountCredited', to_jsonb(aggregated_amounts.total_credited)
+        )
     )
 FROM aggregated_amounts
 WHERE encumbrance.id = aggregated_amounts.encumbrance_id;

--- a/src/main/resources/templates/db_scripts/migration/extract_credits_from_expenditures.sql
+++ b/src/main/resources/templates/db_scripts/migration/extract_credits_from_expenditures.sql
@@ -40,11 +40,14 @@ WITH aggregated_amounts AS (
 )
 UPDATE ${myuniversity}_${mymodule}.transaction AS encumbrance
 SET
-    jsonb = jsonb || jsonb_build_object(
-        'encumbrance', jsonb_build_object(
-            'amountExpended', to_jsonb(aggregated_amounts.total_expended),
-            'amountCredited', to_jsonb(aggregated_amounts.total_credited)
-        )
+    jsonb = jsonb_set(
+        jsonb_set(
+            encumbrance.jsonb,
+            '{encumbrance,amountExpended}',
+            to_jsonb(aggregated_amounts.total_expended)
+        ),
+        '{encumbrance,amountCredited}',
+        to_jsonb(aggregated_amounts.total_credited)
     )
 FROM aggregated_amounts
 WHERE encumbrance.id = aggregated_amounts.encumbrance_id;


### PR DESCRIPTION
<!--
  If you have a relevant JIRA issue number, please put it in the issue title.
  Example: MODFISTO-70 Logging Improvement

  TL;DR
    - https://www.youtube.com/watch?v=5aHmO_S8FQ4
    - http://www.olitreadwell.com/2016/05/22/how-to-write-great-pull-requests/
    - https://www.atlassian.com/blog/git/written-unwritten-guide-pull-requests
-->

## Purpose
failied in run migration script
https://folio-org.atlassian.net/browse/MODFISTO-511
## Approach
- used jsonb || jsonb_build_object to bypass version lock system