### PR TITLE
[MODINVOICE-563] Encumbrance value incorrect after paying credit invoice

### DIFF
--- a/src/main/java/org/folio/service/transactions/batch/BatchPendingPaymentService.java
+++ b/src/main/java/org/folio/service/transactions/batch/BatchPendingPaymentService.java
@@ -89,9 +89,11 @@ public class BatchPendingPaymentService extends AbstractBatchTransactionService 
   }
 
   private void updateEncumbranceToApplyTransaction(Transaction encumbrance, double amount, CurrencyUnit currency) {
+    if (encumbrance.getEncumbrance().getStatus() == Encumbrance.Status.UNRELEASED) {
+      encumbrance.setAmount(subtractMoney(encumbrance.getAmount(), amount, currency));
+    }
     encumbrance.getEncumbrance().setAmountAwaitingPayment(sumMoney(
       encumbrance.getEncumbrance().getAmountAwaitingPayment(), amount, currency));
-    encumbrance.setAmount(subtractMoney(encumbrance.getAmount(), amount, currency));
   }
 
   private void applyPendingPayments(List<Transaction> pendingPayments, BatchTransactionHolder holder) {


### PR DESCRIPTION
## Purpose
[[MODINVOICE-563] Encumbrance value incorrect after paying credit invoice](https://folio-org.atlassian.net/browse/MODINVOICE-563)

## Approach
- Only update encumbrance amount if status is Unreleased

## Verification
![image](https://github.com/user-attachments/assets/3c7aa49f-577a-4ea0-bc2c-58ad1884250d)
![image](https://github.com/user-attachments/assets/cbc168bc-d39a-43b8-a071-1ff54f73d26a)
