### PR TITLE
[MODFIN-381] - removed duplicate field

### DIFF
--- a/ramls/finance-data.raml
+++ b/ramls/finance-data.raml
@@ -25,7 +25,7 @@ resourceTypes:
 /finance-storage/finance-data:
   type:
     collection-get:
-      exampleCollection: !include acq-models/mod-finance/examples/fy_finance_data_collection.sample
+      exampleCollection: !include acq-models/mod-finance/examples/fy_finance_data_collection_get.sample
       schemaCollection: fy-finance-data-collection
   get:
     description: Get finance data for a fiscal year
@@ -39,7 +39,7 @@ resourceTypes:
     body:
       application/json:
         type: fy-finance-data-collection
-        example: !include acq-models/mod-finance/examples/fy_finance_data_collection.sample
+        example: !include acq-models/mod-finance/examples/fy_finance_data_collection_put.sample
     responses:
       204:
         description: "Items successfully updated"

--- a/src/main/java/org/folio/service/budget/BudgetService.java
+++ b/src/main/java/org/folio/service/budget/BudgetService.java
@@ -56,8 +56,10 @@ public class BudgetService {
     });
   }
 
-  public Future<Void> updateBatchBudgets(List<Budget> budgets, DBConn conn) {
-    budgets.forEach(this::clearReadOnlyFields);
+  public Future<Void> updateBatchBudgets(List<Budget> budgets, DBConn conn, boolean clearReadOnlyFields) {
+    if (Boolean.TRUE.equals(clearReadOnlyFields)) {
+      budgets.forEach(this::clearReadOnlyFields);
+    }
     return budgetDAO.updateBatchBudgets(budgets, conn);
   }
 

--- a/src/main/java/org/folio/service/financedata/FinanceDataService.java
+++ b/src/main/java/org/folio/service/financedata/FinanceDataService.java
@@ -61,7 +61,7 @@ public class FinanceDataService {
       .toList();
     return budgetService.getBudgetsByIds(budgetIds, conn)
       .map(budgets -> setNewValuesForBudgets(budgets, entity))
-      .compose(budgets -> budgetService.updateBatchBudgets(budgets, conn));
+      .compose(budgets -> budgetService.updateBatchBudgets(budgets, conn, false));
   }
 
   private List<Fund> setNewValuesForFunds(List<Fund> funds, FyFinanceDataCollection entity) {

--- a/src/main/java/org/folio/service/transactions/batch/BatchTransactionService.java
+++ b/src/main/java/org/folio/service/transactions/batch/BatchTransactionService.java
@@ -182,7 +182,7 @@ public class BatchTransactionService {
     if (budgets.isEmpty()) {
       return succeededFuture();
     }
-    return budgetService.updateBatchBudgets(budgets, conn)
+    return budgetService.updateBatchBudgets(budgets, conn, true)
       .onSuccess(v -> logger.info("Batch transactions: successfully updated {} budgets", budgets.size()))
       .onFailure(t -> logger.error("Batch transactions: failed to update budgets, budgets = {}",
         Json.encode(budgets), t))

--- a/src/main/resources/templates/db_scripts/all_finance_data_view.sql
+++ b/src/main/resources/templates/db_scripts/all_finance_data_view.sql
@@ -17,7 +17,6 @@ SELECT
     'budgetName', budget.jsonb ->>'name',
     'budgetStatus', budget.jsonb ->>'budgetStatus',
     'budgetInitialAllocation', budget.jsonb ->>'initialAllocation',
-    'budgetCurrentAllocation', budget.jsonb ->>'allocated',
     'budgetAllowableExpenditure', budget.jsonb ->>'allowableExpenditure',
     'budgetAllowableEncumbrance', budget.jsonb ->>'allowableEncumbrance',
     'budgetAcqUnitIds', budget.jsonb ->'acqUnitIds',

--- a/src/test/java/org/folio/service/fianancedata/FinanceDataServiceTest.java
+++ b/src/test/java/org/folio/service/fianancedata/FinanceDataServiceTest.java
@@ -181,7 +181,6 @@ public class FinanceDataServiceTest {
       .withBudgetName("NAME CHANGED")
       .withBudgetStatus(FyFinanceData.BudgetStatus.INACTIVE)
       .withBudgetInitialAllocation(1000.0)
-      .withBudgetCurrentAllocation(900.0)
       .withBudgetAllowableExpenditure(800.0)
       .withBudgetAllowableEncumbrance(700.0)
       .withBudgetAcqUnitIds(List.of("unit1"));

--- a/src/test/java/org/folio/service/fianancedata/FinanceDataServiceTest.java
+++ b/src/test/java/org/folio/service/fianancedata/FinanceDataServiceTest.java
@@ -100,7 +100,7 @@ public class FinanceDataServiceTest {
       .onComplete(testContext.failing(error -> {
         testContext.verify(() -> {
           assertEquals("Fund service error", error.getMessage());
-          verify(budgetService, never()).updateBatchBudgets(any(), any());
+          verify(budgetService, never()).updateBatchBudgets(any(), any(), any());
           verify(fundService, never()).updateFunds(any(), any());
         });
         testContext.completeNow();
@@ -117,7 +117,7 @@ public class FinanceDataServiceTest {
     when(fundService.getFundsByIds(any(), any())).thenReturn(Future.succeededFuture(List.of(oldFund)));
     when(fundService.updateFunds(any(), any())).thenReturn(Future.succeededFuture());
     when(budgetService.getBudgetsByIds(any(), any())).thenReturn(Future.succeededFuture(List.of(oldBudget)));
-    when(budgetService.updateBatchBudgets(any(), any())).thenReturn(Future.succeededFuture());
+    when(budgetService.updateBatchBudgets(any(), any(), any())).thenReturn(Future.succeededFuture());
   }
 
   private void setupMocksForFailure(RuntimeException expectedError) {
@@ -153,7 +153,7 @@ public class FinanceDataServiceTest {
     assertEquals(collection.getFyFinanceData().get(0).getBudgetId(), budgetIdsCaptor.getValue().get(0));
 
     ArgumentCaptor<List<Budget>> budgetCaptor = ArgumentCaptor.forClass(List.class);
-    verify(budgetService).updateBatchBudgets(budgetCaptor.capture(), eq(dbConn));
+    verify(budgetService).updateBatchBudgets(budgetCaptor.capture(), eq(dbConn), any());
     Budget updatedBudget = budgetCaptor.getValue().get(0);
 
     assertNotEquals("NAME CHANGED", updatedBudget.getName());


### PR DESCRIPTION
<!--
  If you have a relevant JIRA issue number, please put it in the issue title.
  Example: MODFISTO-70 Logging Improvement

  TL;DR
    - https://www.youtube.com/watch?v=5aHmO_S8FQ4
    - http://www.olitreadwell.com/2016/05/22/how-to-write-great-pull-requests/
    - https://www.atlassian.com/blog/git/written-unwritten-guide-pull-requests
-->

## Purpose
<!--
  Why are you making this change? There is nothing more important
  to provide to the reviewer and to future readers than the cause
  that gave rise to this pull request. Be careful to avoid circular
  statements like "the purpose is to update the schema."
  instead, provide an explanation like "there is more data to be provided and stored for Purchase Orders
  which is currently missing in the schema"

  The purpose may seem self-evident to you now, but the standard to
  hold yourself to should be "can a developer parachuting into this
  the project reconstructs the necessary context merely by reading this
  section."

  If you have a relevant JIRA issue, add a link directly to the issue URL here.
  Example: https://issues.folio.org/browse/MODFISTO-70
 -->
https://folio-org.atlassian.net/browse/MODFIN-381
## Approach
Removed after pr https://github.com/folio-org/acq-models/pull/493#event-15559912996
updated budget batch update methods to keep original value of read only fields to avoid being set to null when budgets is being updated with fields in scope of finance data service