### PR TITLE
[MODFISTO-417] and [MODFISTO-491] Fix encumbrance order properties

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@
 /.checkstyle
 /.classpath
 /.project
+.env

--- a/scripts/fix_encumbrances/README.md
+++ b/scripts/fix_encumbrances/README.md
@@ -43,6 +43,7 @@ These can be set with a permission group created with the API.
 - `finance-storage.transactions.batch.execute`
 - `finance-storage.budgets.item.put`
 - `orders-storage.purchase-orders.collection.get`
+- `orders-storage.purchase-orders.item.get`
 - `orders-storage.po-lines.collection.get`
 - `orders-storage.po-lines.item.get`
 - `orders-storage.po-lines.item.put`
@@ -67,9 +68,10 @@ After the script is launched, it is possible to select a dry-run mode. This will
 After the mode selection, it is possible to select the operation(s) to execute:
 
 - Run all fixes (can be long).
-- Remove duplicate encumbrances (one released, one unreleased for the same thing).
+- Remove duplicate encumbrances (remove one when 2 encumbrances have the same `orderId`/`sourcePoLineId`/`fromFundId`/`expenseClassId`/`fiscalYearId`).
 - Fix order line - encumbrance relations: fix `encumbrance` links in PO lines in case the poline fund distribution refers to the encumbrance from the previous fiscal year; also fix the fund id in encumbrances if they don't match their po line distribution fund id. This whole step is disabled for past fiscal years.
-- Fix the `orderStatus` property of encumbrances for closed orders. In order to do this, the encumbrances have to be unreleased first and released afterward because it is not possible to change this property for released encumbrances.
+- Fix the `orderStatus` property of encumbrances for closed orders.
+- Fix the `orderStatus`, `orderType` and `reEncumber` properties of encumbrances for open and pending orders.
 - Remove pending order links to encumbrances in previous fiscal years (Quesnelia+ version only; current fiscal year only) - this resolves an issue when opening a pending order after FYRO. It only removes encumbrance links if they use a fund without an active budget.
 - Change the encumbrance status to `Unreleased` for all open orders' encumbrances with non-zero amounts.
 - Release open order unreleased encumbrances with negative amounts when they have `amountAwaitingPayment` or `amountExpended` > 0.
@@ -92,3 +94,5 @@ After the mode selection, it is possible to select the operation(s) to execute:
 - [MODFISTO-425](https://folio-org.atlassian.net/browse/MODFISTO-425) - Disable fixing encumbrance fund id for past fiscal years
 - [MODFISTO-462](https://folio-org.atlassian.net/browse/MODFISTO-462) - Update the encumbrance script to use the new transaction API
 - [MODFISTO-514](https://folio-org.atlassian.net/browse/MODFISTO-514) - Remove links to encumbrances for pending orders in an old FY
+- [MODFISTO-417](https://folio-org.atlassian.net/browse/MODFISTO-417) - Fix encumbrances with a bad orderType
+- [MODFISTO-491](https://folio-org.atlassian.net/browse/MODFISTO-491) - Fix inconsistent reEncumber values


### PR DESCRIPTION
## Purpose
- [MODFISTO-417](https://folio-org.atlassian.net/browse/MODFISTO-417) - Fix encumbrances with a bad orderType
- [MODFISTO-491](https://folio-org.atlassian.net/browse/MODFISTO-491) - Fix inconsistent reEncumber values

## Approach
- Added a new step to fix encumbrance properties (orderStatus, orderType, reEncumber) for open and pending orders.
- Remove more duplicate encumbrances. Previously it only checked released/unreleased duplicates; now it checks for all encumbrances with the same `orderId`/`sourcePoLineId`/`fromFundId`/`expenseClassId`/`fiscalYearId` (still in open and closed orders). Also the script tries to be smart when choosing which encumbrance to remove.
- Removed the code unreleasing encumbrances before changing order properties - this is no longer needed with the new transaction API.
- Avoid loading all closed orders in memory at the same time: when getting ids of records matching a query by chunks, only keep the ids and the order chunk in memory.
- When checking poline-order relations, check the fiscal year in the same way as elsewhere, for consistency. Also use the same max number of active threads as elsewhere.
- Updated the README.
- Added `.env` to `gitignore` for python environments.

## Pre-Merge Checklist:
Before merging this PR, please go through the following list and take appropriate actions.

- Does this PR meet or exceed the expected quality standards?
  - [ ] Code coverage on new code is 80% or greater
  - [ ] Duplications on new code is 3% or less
  - [ ] There are no major code smells or security issues
- Does this introduce breaking changes?
  - [ ] Were any API paths or methods changed, added or removed?
  - [ ] Were there any schema changes?
  - [ ] Did any of the interface versions change?
  - [ ] Were permissions changed, added or removed?
  - [ ] Are there new interface dependencies?
  - [ ] There are no breaking changes in this PR.

If there are breaking changes, please **STOP** and consider the following:

- What other modules will these changes impact?
- Do JIRAs exist to update the impacted modules?
  - [ ] If not, please create them
  - [ ] Do they contain the appropriate level of detail?  Which endpoints/schemas changed, etc.
  - [ ] Do they have all the appropriate links to blocked/related issues?
- Are the JIRAs under active development?
  - [ ] If not, contact the project's PO and make sure they're aware of the urgency.
- Do PRs exist for these changes?
  - [ ] If so, have they been approved?
- Did you modify code to call some additional endpoints?
  - [ ] If so, do you check that necessary module permission added in ModuleDescriptor-template.yaml file?

Ideally, all the PRs involved in breaking changes would be merged on the same day
to avoid breaking the folio-testing environment.
Communication is paramount if that is to be achieved,
especially as the number of inter-module and inter-team dependencies increase.

While it's helpful for reviewers to help identify potential problems,
ensuring that it's safe to merge is ultimately the responsibility of the PR assignee.
