### PR TITLE
Fixed f-string syntax for pre-3.12 python

### DIFF
--- a/scripts/fix_encumbrances/fix_encumbrances_quesnelia.py
+++ b/scripts/fix_encumbrances/fix_encumbrances_quesnelia.py
@@ -195,16 +195,10 @@ async def get_transactions_by_query(query) -> list:
     return transactions
 
 
-async def get_transactions_by_ids(transaction_ids) -> list:
-    query = f'id==({' OR '.join(transaction_ids)})'
-    transactions = await get_transactions_by_query(query)
-    return transactions
-
-
 async def get_polines_by_ids(poline_ids) -> list:
     polines = []
     for poline_ids_chunk in chunks(poline_ids, IDS_CHUNK):
-        query = f'id==({' OR '.join(poline_ids_chunk)})'
+        query = f"id==({' OR '.join(poline_ids_chunk)})"
         polines_chunk = await get_request(okapi_url + 'orders-storage/po-lines', query, 'poLines')
         polines.extend(polines_chunk)
     return polines
@@ -645,7 +639,7 @@ async def get_encumbrances_to_fix_properties(order, fiscal_year_id) -> list:
 
 async def fix_encumbrances_properties(order, encumbrances):
     try:
-        print(f'\n  Fixing the following encumbrance(s) for order {order['id']} :')
+        print(f"\n  Fixing the following encumbrance(s) for order {order['id']} :")
         for encumbrance in encumbrances:
             print(f"    {encumbrance['id']}")
             encumbrance['encumbrance']['orderStatus'] = order['workflowStatus']
@@ -653,7 +647,7 @@ async def fix_encumbrances_properties(order, encumbrances):
             encumbrance['encumbrance']['reEncumber'] = order['reEncumber']
         await batch_update(encumbrances)
     except Exception as err:
-        print(f'Error when fixing encumbrance properties for order {order['id']}:', err)
+        print(f"Error when fixing encumbrance properties for order {order['id']}:", err)
         raise SystemExit(1)
 
 
@@ -693,7 +687,7 @@ async def fix_encumbrance_properties_for_open_and_pending_orders(fiscal_year_id)
 
 async def get_orders_encumbrances_with_different_fy(order_ids, fiscal_year_id) -> list:
     url = okapi_url + 'finance-storage/transactions'
-    ids = f'({' OR '.join(order_ids)})'
+    ids = f"({' OR '.join(order_ids)})"
     query = f'encumbrance.sourcePurchaseOrderId=={ids} AND fiscalYearId<>{fiscal_year_id}'
     transactions = await get_by_chunks(url, query, 'transactions')
     return transactions
@@ -702,7 +696,7 @@ async def get_orders_encumbrances_with_different_fy(order_ids, fiscal_year_id) -
 async def get_active_budgets_by_fund_ids(fund_ids) -> list:
     budgets = []
     for fund_ids_chunk in chunks(fund_ids, IDS_CHUNK):
-        query = f'budgetStatus==Active AND fundId==({' OR '.join(fund_ids_chunk)})'
+        query = f"budgetStatus==Active AND fundId==({' OR '.join(fund_ids_chunk)})"
         budgets_chunk = await get_budgets_by_query(query)
         budgets.extend(budgets_chunk)
     return budgets


### PR DESCRIPTION
## Purpose
Fixed syntax error for pre-3.12 python. See [PEP-701](https://docs.python.org/3.12/whatsnew/3.12.html#pep-701-syntactic-formalization-of-f-strings).

## Approach
- Used different kind of quotes inside f-strings.
- Removed unused function `get_transactions_by_ids`.

## Pre-Merge Checklist:
Before merging this PR, please go through the following list and take appropriate actions.

- Does this PR meet or exceed the expected quality standards?
  - [ ] Code coverage on new code is 80% or greater
  - [ ] Duplications on new code is 3% or less
  - [ ] There are no major code smells or security issues
- Does this introduce breaking changes?
  - [ ] Were any API paths or methods changed, added or removed?
  - [ ] Were there any schema changes?
  - [ ] Did any of the interface versions change?
  - [ ] Were permissions changed, added or removed?
  - [ ] Are there new interface dependencies?
  - [ ] There are no breaking changes in this PR.

If there are breaking changes, please **STOP** and consider the following:

- What other modules will these changes impact?
- Do JIRAs exist to update the impacted modules?
  - [ ] If not, please create them
  - [ ] Do they contain the appropriate level of detail?  Which endpoints/schemas changed, etc.
  - [ ] Do they have all the appropriate links to blocked/related issues?
- Are the JIRAs under active development?
  - [ ] If not, contact the project's PO and make sure they're aware of the urgency.
- Do PRs exist for these changes?
  - [ ] If so, have they been approved?
- Did you modify code to call some additional endpoints?
  - [ ] If so, do you check that necessary module permission added in ModuleDescriptor-template.yaml file?

Ideally, all the PRs involved in breaking changes would be merged on the same day
to avoid breaking the folio-testing environment.
Communication is paramount if that is to be achieved,
especially as the number of inter-module and inter-team dependencies increase.

While it's helpful for reviewers to help identify potential problems,
ensuring that it's safe to merge is ultimately the responsibility of the PR assignee.
