### PR TITLE
[MODFISTO-514] Fixed selecting encumbrances without active budget

### DIFF
--- a/scripts/fix_encumbrances/fix_encumbrances_quesnelia.py
+++ b/scripts/fix_encumbrances/fix_encumbrances_quesnelia.py
@@ -707,8 +707,11 @@ async def select_encumbrances_without_active_budgets(encumbrances) -> list:
         return []
     fund_ids = set(map(lambda enc: enc['fromFundId'], encumbrances))
     budgets = await get_active_budgets_by_fund_ids(fund_ids)
-    ids_of_funds_with_active_budgets = set(map(lambda budget: budget['fundId'], budgets))
-    return list(filter(lambda enc: enc['fromFundId'] not in ids_of_funds_with_active_budgets, encumbrances))
+    return [enc for enc in encumbrances
+        if not any(
+            budget['fundId'] == enc['fromFundId'] and budget['fiscalYearId'] == enc['fiscalYearId']
+            for budget in budgets
+        )]
 
 
 async def remove_links_to_encumbrances(encumbrances) -> int:


### PR DESCRIPTION
## Purpose
[MODFISTO-514](https://folio-org.atlassian.net/browse/MODFISTO-514) - Encumbrance script: remove links to encumbrances for pending orders in an old FY

## Approach
Fixed logic to select encumbrances without an active budget: take into account the budget fiscal year.

[Previous PR for MODFISTO-514](https://github.com/folio-org/mod-finance-storage/pull/444)

## Pre-Merge Checklist:
Before merging this PR, please go through the following list and take appropriate actions.

- Does this PR meet or exceed the expected quality standards?
  - [ ] Code coverage on new code is 80% or greater
  - [ ] Duplications on new code is 3% or less
  - [ ] There are no major code smells or security issues
- Does this introduce breaking changes?
  - [ ] Were any API paths or methods changed, added or removed?
  - [ ] Were there any schema changes?
  - [ ] Did any of the interface versions change?
  - [ ] Were permissions changed, added or removed?
  - [ ] Are there new interface dependencies?
  - [ ] There are no breaking changes in this PR.

If there are breaking changes, please **STOP** and consider the following:

- What other modules will these changes impact?
- Do JIRAs exist to update the impacted modules?
  - [ ] If not, please create them
  - [ ] Do they contain the appropriate level of detail?  Which endpoints/schemas changed, etc.
  - [ ] Do they have all the appropriate links to blocked/related issues?
- Are the JIRAs under active development?
  - [ ] If not, contact the project's PO and make sure they're aware of the urgency.
- Do PRs exist for these changes?
  - [ ] If so, have they been approved?
- Did you modify code to call some additional endpoints?
  - [ ] If so, do you check that necessary module permission added in ModuleDescriptor-template.yaml file?

Ideally, all the PRs involved in breaking changes would be merged on the same day
to avoid breaking the folio-testing environment.
Communication is paramount if that is to be achieved,
especially as the number of inter-module and inter-team dependencies increase.

While it's helpful for reviewers to help identify potential problems,
ensuring that it's safe to merge is ultimately the responsibility of the PR assignee.
