### PR TITLE
[MODFISTO-515] Do not process 0-amount encumbrances before deleting

### DIFF
--- a/src/main/java/org/folio/service/transactions/batch/BatchTransactionHolder.java
+++ b/src/main/java/org/folio/service/transactions/batch/BatchTransactionHolder.java
@@ -40,6 +40,7 @@ import static java.util.stream.Collectors.toCollection;
 import static java.util.stream.Collectors.toMap;
 import static java.util.stream.Collectors.toSet;
 import static org.folio.rest.jaxrs.model.Transaction.TransactionType.CREDIT;
+import static org.folio.rest.jaxrs.model.Transaction.TransactionType.ENCUMBRANCE;
 import static org.folio.rest.jaxrs.model.Transaction.TransactionType.PAYMENT;
 import static org.folio.rest.jaxrs.model.Transaction.TransactionType.PENDING_PAYMENT;
 import static org.folio.rest.util.ErrorCodes.LINKED_ENCUMBRANCES_NOT_FOUND;
@@ -185,7 +186,10 @@ public class BatchTransactionHolder {
         if (transactions.size() != idsOfTransactionsToDelete.size()) {
           throw new HttpException(400, "One or more transaction to delete was not found");
         }
-        transactionsToCancelAndDelete = transactions;
+        // Do not process 0-amount encumbrances, just delete them (so no budget activity check is done)
+        transactionsToCancelAndDelete = transactions.stream()
+          .filter(tr -> tr.getTransactionType() != ENCUMBRANCE || tr.getAmount() != 0d)
+          .toList();
         return transactionsToCancelAndDelete;
       });
   }

--- a/src/test/java/org/folio/service/transactions/EncumbranceTest.java
+++ b/src/test/java/org/folio/service/transactions/EncumbranceTest.java
@@ -36,7 +36,6 @@ import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.instanceOf;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
-import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyList;
 import static org.mockito.ArgumentMatchers.anyString;
@@ -195,8 +194,6 @@ public class EncumbranceTest extends BatchTransactionServiceTestBase {
     doReturn(tenantId)
       .when(conn).getTenantId();
 
-    setupFundBudgetLedger(fundId, fiscalYearId, 0d, 0d, 0d, 0d, false, false, false);
-
     Criterion criterion = createCriterionByIds(List.of(encumbranceId));
     doReturn(succeededFuture(createResults(List.of(transaction))))
       .when(conn).get(eq(TRANSACTIONS_TABLE), eq(Transaction.class), argThat(
@@ -207,9 +204,6 @@ public class EncumbranceTest extends BatchTransactionServiceTestBase {
     doReturn(succeededFuture(createResults(List.of())))
       .when(conn).get(eq(TRANSACTIONS_TABLE), eq(Transaction.class), argThat(
         crit -> crit.toString().equals(criterionBuilder.build().toString())));
-
-    doAnswer(invocation -> succeededFuture(createRowSet(invocation.getArgument(1))))
-      .when(conn).updateBatch(anyString(), anyList());
 
     doAnswer(invocation -> succeededFuture(createRowSet(List.of(transaction))))
       .when(conn).delete(anyString(), any(Criterion.class));
@@ -228,16 +222,6 @@ public class EncumbranceTest extends BatchTransactionServiceTestBase {
           assertThat(deleteTableNames.get(0), equalTo(TRANSACTIONS_TABLE));
           Criterion deleteCriterion = deleteCriterions.get(0);
           assertThat(deleteCriterion.toString(), equalTo(expectedCriterion.toString()));
-
-          // Verify budget update did not change anything
-          ArgumentCaptor<String> updateTableNamesCaptor = ArgumentCaptor.forClass(String.class);
-          verify(conn, times(1)).updateBatch(updateTableNamesCaptor.capture(), updateEntitiesCaptor.capture());
-          List<String> updateTableNames = updateTableNamesCaptor.getAllValues();
-          List<List<Object>> updateEntities = updateEntitiesCaptor.getAllValues();
-          assertThat(updateTableNames.get(0), equalTo(BUDGET_TABLE));
-          Budget savedBudget = (Budget)(updateEntities.get(0).get(0));
-          assertNull(savedBudget.getMetadata().getUpdatedDate());
-          assertThat(savedBudget.getEncumbered(), equalTo(0d));
         });
         testContext.completeNow();
       });


### PR DESCRIPTION
## Purpose
[MODFISTO-515](https://folio-org.atlassian.net/browse/MODFISTO-515) - Support deleting pending payments with batch transaction API

## Approach
This PR fixes an issue with the [previous one](https://github.com/folio-org/mod-finance-storage/pull/465), which was causing the test for [MODORDERS-1253](https://folio-org.atlassian.net/browse/MODORDERS-1253) (`change-pending-distribution-with-inactive-budget`) to fail. The implementation for MODORDERS-1253 relies on the fact that budget activity is not checked for 0-amount encumbrances to delete.

## Pre-Merge Checklist:
Before merging this PR, please go through the following list and take appropriate actions.

- Does this PR meet or exceed the expected quality standards?
  - [ ] Code coverage on new code is 80% or greater
  - [ ] Duplications on new code is 3% or less
  - [ ] There are no major code smells or security issues
- Does this introduce breaking changes?
  - [ ] Were any API paths or methods changed, added or removed?
  - [ ] Were there any schema changes?
  - [ ] Did any of the interface versions change?
  - [ ] Were permissions changed, added or removed?
  - [ ] Are there new interface dependencies?
  - [ ] There are no breaking changes in this PR.

If there are breaking changes, please **STOP** and consider the following:

- What other modules will these changes impact?
- Do JIRAs exist to update the impacted modules?
  - [ ] If not, please create them
  - [ ] Do they contain the appropriate level of detail?  Which endpoints/schemas changed, etc.
  - [ ] Do they have all the appropriate links to blocked/related issues?
- Are the JIRAs under active development?
  - [ ] If not, contact the project's PO and make sure they're aware of the urgency.
- Do PRs exist for these changes?
  - [ ] If so, have they been approved?
- Did you modify code to call some additional endpoints?
  - [ ] If so, do you check that necessary module permission added in ModuleDescriptor-template.yaml file?

Ideally, all the PRs involved in breaking changes would be merged on the same day
to avoid breaking the folio-testing environment.
Communication is paramount if that is to be achieved,
especially as the number of inter-module and inter-team dependencies increase.

While it's helpful for reviewers to help identify potential problems,
ensuring that it's safe to merge is ultimately the responsibility of the PR assignee.
