### PR TITLE
BF-1169. Fix incorrect interface for rollover

### DIFF
--- a/descriptors/ModuleDescriptor-template.json
+++ b/descriptors/ModuleDescriptor-template.json
@@ -555,8 +555,8 @@
   ],
   "optional": [
     {
-      "id": "orders",
-      "version": "12.0"
+      "id": "orders.rollover",
+      "version": "1.0"
     }
   ],
   "permissionSets" : [


### PR DESCRIPTION
## Purpose
https://folio-org.atlassian.net/browse/BF-1169
Use correct interface for making /orders/rollover declared in https://github.com/folio-org/mod-orders/blob/5e64ade74aaacd212eb84a98fe70c87e88f12bb3/descriptors/ModuleDescriptor-template.json#L1089C14-L1089C29