### PR TITLE
[MODINVOICE-608]. Negative encumbrances on orders with paid invoices - LOC

### DIFF
--- a/src/main/java/org/folio/service/transactions/batch/BatchTransactionService.java
+++ b/src/main/java/org/folio/service/transactions/batch/BatchTransactionService.java
@@ -36,6 +36,7 @@ import static org.folio.rest.jaxrs.model.Transaction.TransactionType.TRANSFER;
 import static org.folio.utils.MetadataUtils.generateMetadata;
 
 public class BatchTransactionService {
+
   private static final Logger logger = LogManager.getLogger();
   private static final List<TransactionType> transactionTypesInOrder = List.of(ALLOCATION, TRANSFER, PAYMENT,
     PENDING_PAYMENT, ENCUMBRANCE);

--- a/src/test/java/org/folio/service/transactions/BatchTransactionServiceTestBase.java
+++ b/src/test/java/org/folio/service/transactions/BatchTransactionServiceTestBase.java
@@ -64,6 +64,7 @@ import static org.mockito.Mockito.doReturn;
 
 @ExtendWith(VertxExtension.class)
 public abstract class BatchTransactionServiceTestBase {
+
   private AutoCloseable mockitoMocks;
   protected BatchTransactionService batchTransactionService;
 


### PR DESCRIPTION
### **Purpose**

- <https://folio-org.atlassian.net/browse/MODINVOICE-608>

### **Approach**

- Add capping of encumbrance amount on unreleasing to avoid it going negative
  - When reopening a 0-amount ongoing order with a paid invoice
  - When cancelling 1 out of 2 paid invoices made from a 0-amount ongoing order  