### PR TITLE
[MODFISTO-559] Fix encumbrance status after rollover

### DIFF
--- a/src/main/resources/templates/db_scripts/budget_encumbrances_rollover.sql
+++ b/src/main/resources/templates/db_scripts/budget_encumbrances_rollover.sql
@@ -110,6 +110,38 @@ CREATE OR REPLACE FUNCTION ${myuniversity}_${mymodule}.calculate_planned_encumbr
 	END;
 $$ LANGUAGE plpgsql;
 
+CREATE OR REPLACE FUNCTION ${myuniversity}_${mymodule}.calculate_planned_encumbrance_status(_transaction jsonb, _rollover_record jsonb) RETURNS varchar as $$
+  DECLARE
+		encumbrance_rollover jsonb DEFAULT null;
+		rollover_orderType VARCHAR DEFAULT null;
+  BEGIN
+    IF NOT (_transaction->'encumbrance'->>'reEncumber')::boolean
+    THEN
+      RETURN 'Released';
+    END IF;
+		IF
+      _transaction->'encumbrance'->>'orderType'='Ongoing' AND (_transaction->'encumbrance'->>'subscription')::boolean
+		THEN
+      rollover_orderType := 'Ongoing-Subscription';
+    ELSIF
+      _transaction->'encumbrance'->>'orderType'='Ongoing'
+		THEN
+      rollover_orderType := 'Ongoing';
+    ELSIF
+      _transaction->'encumbrance'->>'orderType'='One-Time'
+		THEN
+      rollover_orderType := 'One-time';
+    ELSE
+      RETURN 'Released';
+    END IF;
+    IF _rollover_record @? format('$.encumbrancesRollover[*] ? (@.orderType == "%s")', rollover_orderType)::jsonpath
+    THEN
+      RETURN 'Unreleased';
+    END IF;
+    RETURN 'Released';
+  END;
+$$ LANGUAGE plpgsql;
+
 CREATE OR REPLACE FUNCTION ${myuniversity}_${mymodule}.rollover_order(_order_id text, _rollover_record jsonb) RETURNS VOID as $$
     DECLARE
         missing_penny_with_po_line refcursor;
@@ -139,11 +171,7 @@ CREATE OR REPLACE FUNCTION ${myuniversity}_${mymodule}.rollover_order(_order_id 
                         'amountAwaitingPayment', 0,
                         'amountExpended', 0,
                         'amountCredited', 0,
-                        'status', CASE WHEN input_encumbrancesRolloverLen > 0 THEN
-                                    CASE WHEN (tr.jsonb->'encumbrance'->>'reEncumber')::boolean THEN 'Unreleased' ELSE 'Released' END
-                                  ELSE
-                                    'Released'
-                                  END
+                        'status', ${myuniversity}_${mymodule}.calculate_planned_encumbrance_status(tr.jsonb, _rollover_record)
                     ),
                 'metadata', _rollover_record->'metadata' || jsonb_build_object('createdDate', to_char(clock_timestamp(),'YYYY-MM-DD"T"HH24:MI:SS.MSTZHTZM'))
 

--- a/src/main/resources/templates/db_scripts/budget_encumbrances_rollover.sql
+++ b/src/main/resources/templates/db_scripts/budget_encumbrances_rollover.sql
@@ -112,24 +112,24 @@ $$ LANGUAGE plpgsql;
 
 CREATE OR REPLACE FUNCTION ${myuniversity}_${mymodule}.calculate_planned_encumbrance_status(_transaction jsonb, _rollover_record jsonb) RETURNS varchar as $$
   DECLARE
-		encumbrance_rollover jsonb DEFAULT null;
-		rollover_orderType VARCHAR DEFAULT null;
+    encumbrance_rollover jsonb DEFAULT null;
+    rollover_orderType VARCHAR DEFAULT null;
   BEGIN
     IF NOT (_transaction->'encumbrance'->>'reEncumber')::boolean
     THEN
       RETURN 'Released';
     END IF;
-		IF
+    IF
       _transaction->'encumbrance'->>'orderType'='Ongoing' AND (_transaction->'encumbrance'->>'subscription')::boolean
-		THEN
+    THEN
       rollover_orderType := 'Ongoing-Subscription';
     ELSIF
       _transaction->'encumbrance'->>'orderType'='Ongoing'
-		THEN
+    THEN
       rollover_orderType := 'Ongoing';
     ELSIF
       _transaction->'encumbrance'->>'orderType'='One-Time'
-		THEN
+    THEN
       rollover_orderType := 'One-time';
     ELSE
       RETURN 'Released';
@@ -154,7 +154,6 @@ CREATE OR REPLACE FUNCTION ${myuniversity}_${mymodule}.rollover_order(_order_id 
         input_toFiscalYearId uuid := (_rollover_record->>'toFiscalYearId')::uuid;
         input_ledgerId uuid := (_rollover_record->>'ledgerId')::uuid;
         input_ledgerRolloverId uuid := (_rollover_record->>'id')::uuid;
-				input_encumbrancesRolloverLen int := jsonb_array_length((_rollover_record->>'encumbrancesRollover')::jsonb);
     BEGIN
 
         -- #9 create encumbrances to temp table

--- a/src/main/resources/templates/db_scripts/budget_encumbrances_rollover.sql
+++ b/src/main/resources/templates/db_scripts/budget_encumbrances_rollover.sql
@@ -112,7 +112,6 @@ $$ LANGUAGE plpgsql;
 
 CREATE OR REPLACE FUNCTION ${myuniversity}_${mymodule}.calculate_planned_encumbrance_status(_transaction jsonb, _rollover_record jsonb) RETURNS varchar as $$
   DECLARE
-    encumbrance_rollover jsonb DEFAULT null;
     rollover_orderType VARCHAR DEFAULT null;
   BEGIN
     IF NOT (_transaction->'encumbrance'->>'reEncumber')::boolean

--- a/src/main/resources/templates/db_scripts/schema.json
+++ b/src/main/resources/templates/db_scripts/schema.json
@@ -69,7 +69,7 @@
     {
       "run": "after",
       "snippetPath": "budget_encumbrances_rollover.sql",
-      "fromModuleVersion": "mod-finance-storage-8.9.0"
+      "fromModuleVersion": "mod-finance-storage-9.0.0"
     },
     {
       "run": "after",


### PR DESCRIPTION
## Purpose
[MODFISTO-559](https://folio-org.atlassian.net/browse/MODFISTO-559) - Fix ledger rollover logic to handle encumbrances correctly when only one type is selected

## Approach
Fixed calculation of encumbrance status for encumbrances in the new fiscal year during rollover.

## Related PRs
- [mod-orders](https://github.com/folio-org/mod-orders/pull/1323)
- [folio-integration-tests](https://github.com/folio-org/folio-integration-tests/pull/2390)

---

### **Pre-Review Checklist**

- [ ] **Self-reviewed Code** — Reviewed code for issues, unnecessary parts, and overall quality.
- [ ] **Change Notes** — NEWS.md updated with clear description and issue key.
- [ ] **Testing** — Confirmed changes were tested locally or on dev environment.
- [ ] **Logging**: Confirmed that logging is appropriately handled.
- [ ] **Breaking Changes** — Handled all required actions if changes affect API, DB, or interface versions.
  - [ ] API/schema changes
  - [ ] Interface version updates
  - [ ] DB schema changes / migration scripts
- [ ] **New Properties / Environment Variables** — Updated README.md if new configs were added.
