### PR TITLE
Trillium release v8.9.1

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,4 +1,12 @@
-## 8.9.0 - Released (Trillium R1 2025)
+## 8.9.1 - Released (Trillium R1 2026 Bug Fix)
+This release fixes issue with ledger rollover logic to handle encumbrances correctly when only one type is selected.
+
+[Full Changelog](https://github.com/folio-org/mod-finance-storage/compare/v8.9.0...v8.9.1)
+
+### Bug fixes
+* [MODFISTO-560](https://folio-org.atlassian.net/browse/MODFISTO-560) Fix ledger rollover logic to handle encumbrances correctly when only one type is selected
+
+## 8.9.0 - Released (Trillium R1 2026)
 The primary focus of this release was to upgrade to Vert.x 5.0, implement batch endpoints, alternate exchange rate API and fix encumbrance issues.
 
 [Full Changelog](https://github.com/folio-org/mod-finance-storage/compare/v8.8.0...v8.9.0)

--- a/pom.xml
+++ b/pom.xml
@@ -2,7 +2,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>org.folio</groupId>
   <artifactId>mod-finance-storage</artifactId>
-  <version>8.9.1</version>
+  <version>8.9.2-SNAPSHOT</version>
   <packaging>jar</packaging>
 
   <licenses>
@@ -542,7 +542,7 @@
     <url>https://github.com/folio-org/mod-finance-storage</url>
     <connection>scm:git:git://github.com/folio-org/mod-finance-storage.git</connection>
     <developerConnection>scm:git:git@github.com:folio-org/mod-finance-storage.git</developerConnection>
-    <tag>v8.9.1</tag>
+    <tag>v8.9.0</tag>
   </scm>
 
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -2,7 +2,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>org.folio</groupId>
   <artifactId>mod-finance-storage</artifactId>
-  <version>8.9.1-SNAPSHOT</version>
+  <version>8.9.1</version>
   <packaging>jar</packaging>
 
   <licenses>
@@ -542,7 +542,7 @@
     <url>https://github.com/folio-org/mod-finance-storage</url>
     <connection>scm:git:git://github.com/folio-org/mod-finance-storage.git</connection>
     <developerConnection>scm:git:git@github.com:folio-org/mod-finance-storage.git</developerConnection>
-    <tag>v8.9.0</tag>
+    <tag>v8.9.1</tag>
   </scm>
 
 </project>

--- a/src/main/resources/templates/db_scripts/budget_encumbrances_rollover.sql
+++ b/src/main/resources/templates/db_scripts/budget_encumbrances_rollover.sql
@@ -110,6 +110,37 @@ CREATE OR REPLACE FUNCTION ${myuniversity}_${mymodule}.calculate_planned_encumbr
 	END;
 $$ LANGUAGE plpgsql;
 
+CREATE OR REPLACE FUNCTION ${myuniversity}_${mymodule}.calculate_planned_encumbrance_status(_transaction jsonb, _rollover_record jsonb) RETURNS varchar as $$
+  DECLARE
+    rollover_orderType VARCHAR DEFAULT null;
+  BEGIN
+    IF NOT (_transaction->'encumbrance'->>'reEncumber')::boolean
+    THEN
+      RETURN 'Released';
+    END IF;
+    IF
+      _transaction->'encumbrance'->>'orderType'='Ongoing' AND (_transaction->'encumbrance'->>'subscription')::boolean
+    THEN
+      rollover_orderType := 'Ongoing-Subscription';
+    ELSIF
+      _transaction->'encumbrance'->>'orderType'='Ongoing'
+    THEN
+      rollover_orderType := 'Ongoing';
+    ELSIF
+      _transaction->'encumbrance'->>'orderType'='One-Time'
+    THEN
+      rollover_orderType := 'One-time';
+    ELSE
+      RETURN 'Released';
+    END IF;
+    IF _rollover_record @? format('$.encumbrancesRollover[*] ? (@.orderType == "%s")', rollover_orderType)::jsonpath
+    THEN
+      RETURN 'Unreleased';
+    END IF;
+    RETURN 'Released';
+  END;
+$$ LANGUAGE plpgsql;
+
 CREATE OR REPLACE FUNCTION ${myuniversity}_${mymodule}.rollover_order(_order_id text, _rollover_record jsonb) RETURNS VOID as $$
     DECLARE
         missing_penny_with_po_line refcursor;
@@ -122,7 +153,6 @@ CREATE OR REPLACE FUNCTION ${myuniversity}_${mymodule}.rollover_order(_order_id 
         input_toFiscalYearId uuid := (_rollover_record->>'toFiscalYearId')::uuid;
         input_ledgerId uuid := (_rollover_record->>'ledgerId')::uuid;
         input_ledgerRolloverId uuid := (_rollover_record->>'id')::uuid;
-				input_encumbrancesRolloverLen int := jsonb_array_length((_rollover_record->>'encumbrancesRollover')::jsonb);
     BEGIN
 
         -- #9 create encumbrances to temp table
@@ -139,11 +169,7 @@ CREATE OR REPLACE FUNCTION ${myuniversity}_${mymodule}.rollover_order(_order_id 
                         'amountAwaitingPayment', 0,
                         'amountExpended', 0,
                         'amountCredited', 0,
-                        'status', CASE WHEN input_encumbrancesRolloverLen > 0 THEN
-                                    CASE WHEN (tr.jsonb->'encumbrance'->>'reEncumber')::boolean THEN 'Unreleased' ELSE 'Released' END
-                                  ELSE
-                                    'Released'
-                                  END
+                        'status', ${myuniversity}_${mymodule}.calculate_planned_encumbrance_status(tr.jsonb, _rollover_record)
                     ),
                 'metadata', _rollover_record->'metadata' || jsonb_build_object('createdDate', to_char(clock_timestamp(),'YYYY-MM-DD"T"HH24:MI:SS.MSTZHTZM'))
 

--- a/src/main/resources/templates/db_scripts/schema.json
+++ b/src/main/resources/templates/db_scripts/schema.json
@@ -69,7 +69,7 @@
     {
       "run": "after",
       "snippetPath": "budget_encumbrances_rollover.sql",
-      "fromModuleVersion": "mod-finance-storage-9.0.0"
+      "fromModuleVersion": "mod-finance-storage-8.9.1"
     },
     {
       "run": "after",

--- a/src/main/resources/templates/db_scripts/schema.json
+++ b/src/main/resources/templates/db_scripts/schema.json
@@ -69,7 +69,7 @@
     {
       "run": "after",
       "snippetPath": "budget_encumbrances_rollover.sql",
-      "fromModuleVersion": "mod-finance-storage-8.9.0"
+      "fromModuleVersion": "mod-finance-storage-9.0.0"
     },
     {
       "run": "after",


### PR DESCRIPTION
## 8.9.1 - Released (Trillium R1 2026 Bug Fix)
This release fixes issue with ledger rollover logic to handle encumbrances correctly when only one type is selected.

[Full Changelog](https://github.com/folio-org/mod-finance-storage/compare/v8.9.0...v8.9.1)

### Bug fixes
* [MODFISTO-560](https://folio-org.atlassian.net/browse/MODFISTO-560) Fix ledger rollover logic to handle encumbrances correctly when only one type is selected