### PR TITLE
[MODFISTO-562] Resolve issues with dependantbot version upgrades

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -25,7 +25,7 @@
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 
     <!--Dependency Properties-->
-    <vertx.version>5.0.8</vertx.version>
+    <vertx.version>5.1.1</vertx.version>
     <log4j.version>2.25.3</log4j.version>
     <aspectj.version>1.9.25.1</aspectj.version>
     <jackson-bom.version>2.21.1</jackson-bom.version>
@@ -43,7 +43,7 @@
     <maven-antrun-plugin.version>3.2.0</maven-antrun-plugin.version>
     <maven-shade-plugin.version>3.6.2</maven-shade-plugin.version>
     <maven-release-plugin.version>3.3.1</maven-release-plugin.version>
-    <maven-surefire-plugin.version>3.5.5</maven-surefire-plugin.version>
+    <maven-surefire-plugin.version>3.5.6</maven-surefire-plugin.version>
     <build-helper-maven-plugin.version>3.6.1</build-helper-maven-plugin.version>
     <copy-rename-maven-plugin.version>1.0.1</copy-rename-maven-plugin.version>
 

--- a/src/test/java/org/folio/dao/rollover/RolloverBudgetDAOTest.java
+++ b/src/test/java/org/folio/dao/rollover/RolloverBudgetDAOTest.java
@@ -4,10 +4,9 @@ import io.vertx.core.Future;
 import io.vertx.core.json.JsonObject;
 import io.vertx.junit5.VertxExtension;
 import io.vertx.junit5.VertxTestContext;
-import io.vertx.pgclient.impl.RowImpl;
 import io.vertx.sqlclient.Row;
 import io.vertx.sqlclient.RowSet;
-import io.vertx.sqlclient.internal.RowDesc;
+import io.vertx.sqlclient.impl.RowBase;
 import org.folio.rest.jaxrs.model.LedgerFiscalYearRolloverBudget;
 import org.folio.rest.persist.Criteria.Criterion;
 import org.folio.rest.persist.DBConn;
@@ -84,8 +83,8 @@ public class RolloverBudgetDAOTest {
     LedgerFiscalYearRolloverBudget budget = new LedgerFiscalYearRolloverBudget().withId(id);
     List<LedgerFiscalYearRolloverBudget> budgets = List.of(budget);
 
-    RowDesc rowDesc = createRowDesc("foo");
-    Row row = new RowImpl(rowDesc);
+    var rowDesc = createRowDesc("foo");
+    Row row = new RowBase(rowDesc);
     row.addJsonObject(new JsonObject().put("id", id));
     RowSet<Row> rows = new LocalRowSet(1).withRows(List.of(row));
     doReturn(Future.succeededFuture(rows)).when(conn)

--- a/src/test/java/org/folio/service/ServiceTestUtils.java
+++ b/src/test/java/org/folio/service/ServiceTestUtils.java
@@ -1,31 +1,32 @@
 package org.folio.service;
 
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.when;
-
 import io.vertx.core.json.JsonObject;
-import io.vertx.pgclient.impl.RowImpl;
 import io.vertx.sqlclient.Row;
 import io.vertx.sqlclient.RowSet;
-import io.vertx.sqlclient.internal.RowDesc;
+import io.vertx.sqlclient.desc.ColumnDescriptor;
+import io.vertx.sqlclient.impl.RowBase;
+import io.vertx.sqlclient.internal.RowDescriptorBase;
+import org.folio.rest.persist.helpers.LocalColumnDescriptor;
 import org.folio.rest.persist.helpers.LocalRowSet;
 import org.folio.rest.persist.interfaces.Results;
 
 import java.lang.reflect.InvocationTargetException;
+import java.util.Arrays;
 import java.util.List;
 
 public class ServiceTestUtils {
 
-  public static RowDesc createRowDesc(String... columnNames) {
-    var rowDesc = mock(RowDesc.class);
-    when(rowDesc.columnNames()).thenReturn(List.of(columnNames));
-    return rowDesc;
+  public static RowDescriptorBase createRowDesc(String... columnNames) {
+    ColumnDescriptor[] descriptors = Arrays.stream(columnNames)
+      .map(LocalColumnDescriptor::new)
+      .toArray(ColumnDescriptor[]::new);
+    return new RowDescriptorBase(descriptors);
   }
 
   public static <T> RowSet<Row> createRowSet(List<T> list) {
     var rowDesc = createRowDesc("foo");
     List<Row> rows = list.stream().map(item -> {
-      Row row = new RowImpl(rowDesc);
+      Row row = new RowBase(rowDesc);
       row.addJsonObject(JsonObject.mapFrom(item));
       return row;
     }).toList();

--- a/src/test/java/org/folio/service/rollover/RolloverValidationServiceTest.java
+++ b/src/test/java/org/folio/service/rollover/RolloverValidationServiceTest.java
@@ -28,11 +28,10 @@ import io.vertx.core.Future;
 import org.folio.rest.exception.HttpException;
 import io.vertx.junit5.VertxExtension;
 import io.vertx.junit5.VertxTestContext;
-import io.vertx.pgclient.impl.RowImpl;
 import io.vertx.sqlclient.Row;
 import io.vertx.sqlclient.RowSet;
 import io.vertx.sqlclient.Tuple;
-import io.vertx.sqlclient.internal.RowDesc;
+import io.vertx.sqlclient.impl.RowBase;
 
 @ExtendWith(VertxExtension.class)
 public class RolloverValidationServiceTest {
@@ -66,8 +65,8 @@ public class RolloverValidationServiceTest {
 
     when(conn.getTenantId()).thenReturn("test");
 
-    RowDesc rowDesc = createRowDesc("foo");
-    Row row = new RowImpl(rowDesc);
+    var rowDesc = createRowDesc("foo");
+    Row row = new RowBase(rowDesc);
     row.addBoolean(false);
     RowSet<Row> rows = new LocalRowSet(1).withRows(List.of(row));
     doReturn(Future.succeededFuture(rows))
@@ -91,8 +90,8 @@ public class RolloverValidationServiceTest {
 
     when(conn.getTenantId()).thenReturn("test");
 
-    RowDesc rowDesc = createRowDesc("foo");
-    Row row = new RowImpl(rowDesc);
+    var rowDesc = createRowDesc("foo");
+    Row row = new RowBase(rowDesc);
     row.addBoolean(true);
     RowSet<Row> rows = new LocalRowSet(1).withRows(List.of(row));
     doReturn(Future.succeededFuture(rows))


### PR DESCRIPTION
### **Purpose**
[MODFISTO-562](https://folio-org.atlassian.net/browse/MODFISTO-562) - Resolve issues with dependantbot upgrades

### **Approach**
The Vert.x upgrade introduced breaking API changes in the SQL client internals. Three test files were updated to adapt.

#### **Related PR**
Dependabot PR that caused the failures - https://github.com/folio-org/mod-finance-storage/pull/562

### **Pre-Review Checklist**

- [ ] **Self-reviewed Code** — Reviewed code for issues, unnecessary parts, and overall quality.
- [ ] **Change Notes** — NEWS.md updated with clear description and issue key.
- [ ] **Testing** — Confirmed changes were tested locally or on dev environment.
- [ ] **Logging**: Confirmed that logging is appropriately handled.
- [ ] **Breaking Changes** — Handled all required actions if changes affect API, DB, or interface versions.
  - [ ] API/schema changes
  - [ ] Interface version updates
  - [ ] DB schema changes / migration scripts
- [ ] **New Properties / Environment Variables** — Updated README.md if new configs were added.
