### PR TITLE
[MODFISTO-506] Add FiscalYearHierarchy schema, DB view, and GET endpoint

### DIFF
--- a/descriptors/ModuleDescriptor-template.json
+++ b/descriptors/ModuleDescriptor-template.json
@@ -522,6 +522,17 @@
       ]
     },
     {
+      "id": "finance-storage.fiscal-year-hierarchy",
+      "version": "1.0",
+      "handlers": [
+        {
+          "methods": ["GET"],
+          "pathPattern": "/finance-storage/fiscal-year-hierarchy",
+          "permissionsRequired": ["finance-storage.fiscal-year-hierarchy.collection.get"]
+        }
+      ]
+    },
+    {
       "id": "finance-storage.exchange-rate-source",
       "version": "1.0",
       "handlers": [
@@ -1147,6 +1158,19 @@
       ]
     },
     {
+      "permissionName": "finance-storage.fiscal-year-hierarchy.collection.get",
+      "displayName": "all fiscal-year-hierarchy",
+      "description": "Get the ledger/group/fund/budget/expense-class hierarchy for a fiscal year"
+    },
+    {
+      "permissionName": "finance-storage.fiscal-year-hierarchy.all",
+      "displayName": "All fiscal-year-hierarchy perms",
+      "description": "All permissions for the fiscal year hierarchy",
+      "subPermissions": [
+        "finance-storage.fiscal-year-hierarchy.collection.get"
+      ]
+    },
+    {
       "permissionName": "finance-storage.exchange-rate-source.item.get",
       "displayName": "get exchange rate source",
       "description": "Get exchange rate source"
@@ -1199,6 +1223,7 @@
         "finance-storage.fund-types.all",
         "finance-storage.fund-update-logs.all",
         "finance-storage.finance-data.all",
+        "finance-storage.fiscal-year-hierarchy.all",
         "finance-storage.exchange-rate-source.all",
         "finance-storage.job-number.get"
       ]

--- a/ramls/fiscal-year-hierarchy.raml
+++ b/ramls/fiscal-year-hierarchy.raml
@@ -1,0 +1,37 @@
+#%RAML 1.0
+title: "mod-finance-storage"
+baseUri: https://github.com/folio-org/mod-finance-storage
+version: v1
+
+documentation:
+  - title: mod-finance-storage (Fiscal year hierarchy)
+    content: <b>Read-only API for retrieving the ledger/group/fund/budget/expense-class hierarchy for a fiscal year</b>
+
+types:
+  errors: !include raml-util/schemas/errors.schema
+  fiscal-year-hierarchy-collection: !include acq-models/mod-finance/schemas/fiscal_year_hierarchy_collection.json
+
+/finance-storage/fiscal-year-hierarchy:
+  get:
+    description: Get the ledger/group/fund/budget/expense-class hierarchy for a fiscal year, one entry per ledger
+    queryParameters:
+      fiscalYearId:
+        description: UUID of the fiscal year to build the hierarchy for
+        type: string
+        required: true
+    responses:
+      200:
+        body:
+          application/json:
+            type: fiscal-year-hierarchy-collection
+            example: !include acq-models/mod-finance/examples/fiscal_year_hierarchy_collection_get.sample
+      400:
+        description: "Bad request, e.g. missing or malformed fiscalYearId parameter"
+        body:
+          text/plain:
+            example: "unable to process request -- malformed parameter 'fiscalYearId'"
+      500:
+        description: "Internal server error, e.g. due to misconfiguration"
+        body:
+          text/plain:
+            example: "internal server error, contact administrator"

--- a/src/main/java/org/folio/config/DAOConfiguration.java
+++ b/src/main/java/org/folio/config/DAOConfiguration.java
@@ -10,6 +10,8 @@ import org.folio.dao.expense.ExpenseClassDAO;
 import org.folio.dao.expense.ExpenseClassDAOImpl;
 import org.folio.dao.fiscalyear.FiscalYearDAO;
 import org.folio.dao.fiscalyear.FiscalYearPostgresDAO;
+import org.folio.dao.fiscalyearhierarchy.FiscalYearHierarchyDAO;
+import org.folio.dao.fiscalyearhierarchy.FiscalYearHierarchyPostgresDAO;
 import org.folio.dao.fund.FundDAO;
 import org.folio.dao.fund.FundPostgresDAO;
 import org.folio.dao.group.GroupDAO;
@@ -110,6 +112,11 @@ public class DAOConfiguration {
   @Bean
   public TransactionTotalDAO transactionTotalDAO() {
     return new TransactionTotalPostgresDAO();
+  }
+
+  @Bean
+  public FiscalYearHierarchyDAO fiscalYearHierarchyDAO() {
+    return new FiscalYearHierarchyPostgresDAO();
   }
 
 }

--- a/src/main/java/org/folio/dao/fiscalyearhierarchy/FiscalYearHierarchyDAO.java
+++ b/src/main/java/org/folio/dao/fiscalyearhierarchy/FiscalYearHierarchyDAO.java
@@ -1,0 +1,11 @@
+package org.folio.dao.fiscalyearhierarchy;
+
+import io.vertx.core.Future;
+import org.folio.rest.jaxrs.model.FiscalYearHierarchyCollection;
+import org.folio.rest.persist.DBConn;
+
+public interface FiscalYearHierarchyDAO {
+
+  Future<FiscalYearHierarchyCollection> getFiscalYearHierarchy(DBConn conn, String fiscalYearId);
+
+}

--- a/src/main/java/org/folio/dao/fiscalyearhierarchy/FiscalYearHierarchyPostgresDAO.java
+++ b/src/main/java/org/folio/dao/fiscalyearhierarchy/FiscalYearHierarchyPostgresDAO.java
@@ -1,0 +1,111 @@
+package org.folio.dao.fiscalyearhierarchy;
+
+import static org.folio.rest.persist.HelperUtils.getFullTableName;
+
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+import io.vertx.core.Future;
+import io.vertx.core.json.JsonArray;
+import io.vertx.core.json.JsonObject;
+import io.vertx.sqlclient.Row;
+import io.vertx.sqlclient.RowSet;
+import io.vertx.sqlclient.Tuple;
+import org.folio.rest.jaxrs.model.FiscalYearHierarchy;
+import org.folio.rest.jaxrs.model.FiscalYearHierarchyBudget;
+import org.folio.rest.jaxrs.model.FiscalYearHierarchyCollection;
+import org.folio.rest.jaxrs.model.FiscalYearHierarchyExpenseClass;
+import org.folio.rest.jaxrs.model.FiscalYearHierarchyFund;
+import org.folio.rest.jaxrs.model.FiscalYearHierarchyGroup;
+import org.folio.rest.persist.DBConn;
+
+public class FiscalYearHierarchyPostgresDAO implements FiscalYearHierarchyDAO {
+
+  public static final String FISCAL_YEAR_HIERARCHY_VIEW = "fiscal_year_hierarchy_view";
+  private static final String SELECT_BY_FISCAL_YEAR_ID = "SELECT jsonb FROM %s WHERE jsonb ->> 'fiscalYearId' = $1";
+
+  @Override
+  public Future<FiscalYearHierarchyCollection> getFiscalYearHierarchy(DBConn conn, String fiscalYearId) {
+    var sql = SELECT_BY_FISCAL_YEAR_ID.formatted(getFullTableName(conn.getTenantId(), FISCAL_YEAR_HIERARCHY_VIEW));
+    return conn.execute(sql, Tuple.of(fiscalYearId))
+      .map(this::buildHierarchyCollection);
+  }
+
+  private FiscalYearHierarchyCollection buildHierarchyCollection(RowSet<Row> rows) {
+    Map<String, FiscalYearHierarchy> ledgers = new LinkedHashMap<>();
+    Map<String, Map<String, FiscalYearHierarchyGroup>> groupsByLedger = new LinkedHashMap<>();
+
+    for (Row row : rows) {
+      JsonObject flatRow = row.getJsonObject("jsonb");
+      var ledger = ledgers.computeIfAbsent(flatRow.getString("ledgerId"), id -> toLedgerNode(flatRow));
+      var fund = toFundNode(flatRow);
+      var groupId = flatRow.getString("groupId");
+
+      if (groupId == null) {
+        ledger.getFunds().add(fund);
+        continue;
+      }
+      var group = groupsByLedger.computeIfAbsent(ledger.getLedgerId(), id -> new LinkedHashMap<>())
+        .computeIfAbsent(groupId, id -> {
+          var groupNode = toGroupNode(flatRow);
+          ledger.getGroups().add(groupNode);
+          return groupNode;
+        });
+      group.getFunds().add(fund);
+    }
+
+    return new FiscalYearHierarchyCollection()
+      .withFiscalYearHierarchies(List.copyOf(ledgers.values()))
+      .withTotalRecords(ledgers.size());
+  }
+
+  private FiscalYearHierarchy toLedgerNode(JsonObject flatRow) {
+    return new FiscalYearHierarchy()
+      .withFiscalYearId(flatRow.getString("fiscalYearId"))
+      .withFiscalYearCode(flatRow.getString("fiscalYearCode"))
+      .withLedgerId(flatRow.getString("ledgerId"))
+      .withLedgerCode(flatRow.getString("ledgerCode"))
+      .withLedgerName(flatRow.getString("ledgerName"));
+  }
+
+  private FiscalYearHierarchyGroup toGroupNode(JsonObject flatRow) {
+    return new FiscalYearHierarchyGroup()
+      .withGroupId(flatRow.getString("groupId"))
+      .withGroupCode(flatRow.getString("groupCode"))
+      .withGroupName(flatRow.getString("groupName"));
+  }
+
+  private FiscalYearHierarchyFund toFundNode(JsonObject flatRow) {
+    return new FiscalYearHierarchyFund()
+      .withFundId(flatRow.getString("fundId"))
+      .withFundCode(flatRow.getString("fundCode"))
+      .withFundName(flatRow.getString("fundName"))
+      .withBudget(toBudgetNode(flatRow));
+  }
+
+  private FiscalYearHierarchyBudget toBudgetNode(JsonObject flatRow) {
+    var budgetId = flatRow.getString("budgetId");
+    if (budgetId == null) {
+      return null;
+    }
+    return new FiscalYearHierarchyBudget()
+      .withBudgetId(budgetId)
+      .withBudgetName(flatRow.getString("budgetName"))
+      .withBudgetStatus(flatRow.getString("budgetStatus"))
+      .withInitialAllocation(flatRow.getDouble("initialAllocation"))
+      .withAllocated(flatRow.getDouble("allocated"))
+      .withAvailable(flatRow.getDouble("available"))
+      .withBudgetExpenseClasses(toExpenseClasses(flatRow.getJsonArray("budgetExpenseClasses")));
+  }
+
+  private List<FiscalYearHierarchyExpenseClass> toExpenseClasses(JsonArray expenseClasses) {
+    if (expenseClasses == null) {
+      return List.of();
+    }
+    return expenseClasses.stream()
+      .map(o -> ((JsonObject) o).mapTo(FiscalYearHierarchyExpenseClass.class))
+      .toList();
+  }
+
+}

--- a/src/main/java/org/folio/rest/impl/FiscalYearHierarchyApi.java
+++ b/src/main/java/org/folio/rest/impl/FiscalYearHierarchyApi.java
@@ -1,0 +1,50 @@
+package org.folio.rest.impl;
+
+import static org.folio.rest.util.ResponseUtils.buildErrorResponse;
+import static org.folio.rest.util.ResponseUtils.buildOkResponse;
+
+import java.util.Map;
+
+import javax.ws.rs.core.Response;
+
+import io.vertx.core.AsyncResult;
+import io.vertx.core.Context;
+import io.vertx.core.Handler;
+import io.vertx.core.Vertx;
+import org.apache.commons.lang3.StringUtils;
+import org.folio.dao.fiscalyearhierarchy.FiscalYearHierarchyDAO;
+import org.folio.rest.exception.HttpException;
+import org.folio.rest.jaxrs.resource.FinanceStorageFiscalYearHierarchy;
+import org.folio.rest.persist.DBClient;
+import org.folio.spring.SpringContextUtil;
+import org.springframework.beans.factory.annotation.Autowired;
+
+public class FiscalYearHierarchyApi implements FinanceStorageFiscalYearHierarchy {
+
+  @Autowired
+  private FiscalYearHierarchyDAO fiscalYearHierarchyDAO;
+
+  public FiscalYearHierarchyApi() {
+    SpringContextUtil.autowireDependencies(this, Vertx.currentContext());
+  }
+
+  @Override
+  public void getFinanceStorageFiscalYearHierarchy(String fiscalYearId, Map<String, String> okapiHeaders,
+                                                    Handler<AsyncResult<Response>> asyncResultHandler, Context vertxContext) {
+    if (StringUtils.isBlank(fiscalYearId)) {
+      asyncResultHandler.handle(buildErrorResponse(new HttpException(400, "fiscalYearId is required")));
+      return;
+    }
+
+    new DBClient(vertxContext, okapiHeaders)
+      .withConn(conn -> fiscalYearHierarchyDAO.getFiscalYearHierarchy(conn, fiscalYearId))
+      .onComplete(hierarchy -> {
+        if (hierarchy.succeeded()) {
+          asyncResultHandler.handle(buildOkResponse(hierarchy.result()));
+        } else {
+          asyncResultHandler.handle(buildErrorResponse(hierarchy.cause()));
+        }
+      });
+  }
+
+}

--- a/src/main/resources/templates/db_scripts/fiscal_year_hierarchy_view.sql
+++ b/src/main/resources/templates/db_scripts/fiscal_year_hierarchy_view.sql
@@ -1,0 +1,49 @@
+CREATE OR REPLACE VIEW ${myuniversity}_${mymodule}.fiscal_year_hierarchy_view AS
+SELECT
+  ledger.id as id,
+  jsonb_build_object(
+    'fiscalYearId', fiscal_year.id,
+    'fiscalYearCode', fiscal_year.jsonb ->> 'code',
+    'ledgerId', ledger.id,
+    'ledgerCode', ledger.jsonb ->> 'code',
+    'ledgerName', ledger.jsonb ->> 'name',
+    'groupId', groups.id,
+    'groupCode', groups.jsonb ->> 'code',
+    'groupName', groups.jsonb ->> 'name',
+    'fundId', fund.id,
+    'fundCode', fund.jsonb ->> 'code',
+    'fundName', fund.jsonb ->> 'name',
+    'budgetId', budget.id,
+    'budgetName', budget.jsonb ->> 'name',
+    'budgetStatus', budget.jsonb ->> 'budgetStatus',
+    'initialAllocation', (budget.jsonb ->> 'initialAllocation')::numeric,
+    'allocated', (budget.jsonb ->> 'allocated')::numeric,
+    'available', (budget.jsonb ->> 'available')::numeric,
+    'budgetExpenseClasses', (
+      SELECT jsonb_agg(
+        jsonb_build_object(
+          'expenseClassId', expense_class.id,
+          'expenseClassCode', expense_class.jsonb ->> 'code',
+          'expenseClassName', expense_class.jsonb ->> 'name',
+          'status', budget_expense_class.jsonb ->> 'status'
+        )
+      )
+      FROM ${myuniversity}_${mymodule}.budget_expense_class
+      INNER JOIN ${myuniversity}_${mymodule}.expense_class
+        ON expense_class.id = budget_expense_class.expenseclassid
+      WHERE budget_expense_class.budgetid = budget.id
+    )
+  ) as jsonb
+FROM ${myuniversity}_${mymodule}.fiscal_year
+INNER JOIN ${myuniversity}_${mymodule}.fiscal_year fy_one
+  ON fy_one.jsonb ->> 'series' = fiscal_year.jsonb ->> 'series'
+INNER JOIN ${myuniversity}_${mymodule}.ledger
+  ON ledger.fiscalyearoneid = fy_one.id
+INNER JOIN ${myuniversity}_${mymodule}.fund
+  ON fund.ledgerid = ledger.id
+LEFT OUTER JOIN ${myuniversity}_${mymodule}.budget
+  ON budget.fundid = fund.id AND budget.fiscalyearid = fiscal_year.id
+LEFT OUTER JOIN ${myuniversity}_${mymodule}.group_fund_fiscal_year
+  ON group_fund_fiscal_year.fundid = fund.id AND group_fund_fiscal_year.fiscalyearid = fiscal_year.id
+LEFT OUTER JOIN ${myuniversity}_${mymodule}.groups
+  ON groups.id = group_fund_fiscal_year.groupid;

--- a/src/main/resources/templates/db_scripts/schema.json
+++ b/src/main/resources/templates/db_scripts/schema.json
@@ -110,6 +110,11 @@
       "run": "after",
       "snippetPath": "create_job_number_table.sql",
       "fromModuleVersion": "mod-finance-storage-8.8.0"
+    },
+    {
+      "run": "after",
+      "snippetPath": "fiscal_year_hierarchy_view.sql",
+      "fromModuleVersion": "mod-finance-storage-9.0.0"
     }
   ],
   "tables": [

--- a/src/test/java/org/folio/StorageTestSuite.java
+++ b/src/test/java/org/folio/StorageTestSuite.java
@@ -26,6 +26,7 @@ import org.folio.rest.impl.BudgetTest;
 import org.folio.rest.impl.EntitiesCrudTest;
 import org.folio.rest.impl.ExchangeRateSourceTest;
 import org.folio.rest.impl.FinanceDataApiTest;
+import org.folio.rest.impl.FiscalYearHierarchyApiTest;
 import org.folio.rest.impl.FundTest;
 import org.folio.rest.impl.GroupBudgetTest;
 import org.folio.rest.impl.GroupFundFYTest;
@@ -238,6 +239,9 @@ public class StorageTestSuite {
 
   @Nested
   class FinanceDataApiTestNested extends FinanceDataApiTest {}
+
+  @Nested
+  class FiscalYearHierarchyApiTestNested extends FiscalYearHierarchyApiTest {}
 
   @Nested
   class FinanceDataServiceTestNested extends FinanceDataServiceTest {}

--- a/src/test/java/org/folio/rest/impl/FiscalYearHierarchyApiTest.java
+++ b/src/test/java/org/folio/rest/impl/FiscalYearHierarchyApiTest.java
@@ -1,0 +1,161 @@
+package org.folio.rest.impl;
+
+import static org.folio.rest.RestVerticle.OKAPI_HEADER_TENANT;
+import static org.folio.rest.utils.TenantApiTestUtil.deleteTenant;
+import static org.folio.rest.utils.TenantApiTestUtil.prepareTenant;
+import static org.folio.rest.utils.TenantApiTestUtil.purge;
+import static org.folio.rest.utils.TestEntities.BUDGET;
+import static org.folio.rest.utils.TestEntities.BUDGET_EXPENSE_CLASS;
+import static org.folio.rest.utils.TestEntities.EXPENSE_CLASS;
+import static org.folio.rest.utils.TestEntities.FISCAL_YEAR;
+import static org.folio.rest.utils.TestEntities.FUND;
+import static org.folio.rest.utils.TestEntities.GROUP;
+import static org.folio.rest.utils.TestEntities.GROUP_FUND_FY;
+import static org.folio.rest.utils.TestEntities.LEDGER;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.UUID;
+
+import io.restassured.http.Header;
+import io.vertx.core.json.JsonObject;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.folio.rest.jaxrs.model.Budget;
+import org.folio.rest.jaxrs.model.BudgetExpenseClass;
+import org.folio.rest.jaxrs.model.ExpenseClass;
+import org.folio.rest.jaxrs.model.FiscalYear;
+import org.folio.rest.jaxrs.model.FiscalYearHierarchyCollection;
+import org.folio.rest.jaxrs.model.Fund;
+import org.folio.rest.jaxrs.model.Group;
+import org.folio.rest.jaxrs.model.GroupFundFiscalYear;
+import org.folio.rest.jaxrs.model.Ledger;
+import org.folio.rest.jaxrs.model.TenantJob;
+import org.folio.rest.jaxrs.resource.FinanceStorageFiscalYearHierarchy;
+import org.folio.rest.persist.HelperUtils;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+public class FiscalYearHierarchyApiTest extends TestBase {
+  private static final String TENANT_NAME = "fiscalyearhierarchy";
+  private static final Header TENANT_HEADER = new Header(OKAPI_HEADER_TENANT, TENANT_NAME);
+  private static final Logger logger = LogManager.getLogger();
+  private static final String FISCAL_YEAR_HIERARCHY_ENDPOINT = HelperUtils.getEndpoint(FinanceStorageFiscalYearHierarchy.class);
+  private static TenantJob tenantJob;
+
+  @BeforeAll
+  public static void before() {
+    logger.info("Create a new tenant loading the sample data");
+    tenantJob = prepareTenant(TENANT_HEADER, true, true);
+  }
+
+  @AfterAll
+  public static void after() {
+    logger.info("Delete the created \"fiscalyearhierarchy\" tenant");
+    purge(TENANT_HEADER);
+    deleteTenant(tenantJob, TENANT_HEADER);
+  }
+
+  @Test
+  public void positive_testGetHierarchyForFiscalYear() {
+    var fiscalYearId = UUID.randomUUID().toString();
+    var ledgerId = UUID.randomUUID().toString();
+    var groupOneId = UUID.randomUUID().toString();
+    var groupTwoId = UUID.randomUUID().toString();
+    var groupedFundId = UUID.randomUUID().toString();
+    var ungroupedFundId = UUID.randomUUID().toString();
+    var groupedBudgetId = UUID.randomUUID().toString();
+    var ungroupedBudgetId = UUID.randomUUID().toString();
+    var expenseClassId = UUID.randomUUID().toString();
+
+    var fiscalYear = new JsonObject(getFile(FISCAL_YEAR.getPathToSampleFile())).mapTo(FiscalYear.class)
+      .withId(fiscalYearId).withCode("FY2077hier").withName("TEST");
+    createEntity(FISCAL_YEAR.getEndpoint(), fiscalYear, TENANT_HEADER);
+
+    var ledger = new Ledger()
+      .withId(ledgerId).withCode("HIER").withName("Hierarchy ledger")
+      .withFiscalYearOneId(fiscalYearId)
+      .withLedgerStatus(Ledger.LedgerStatus.ACTIVE)
+      .withRestrictEncumbrance(true).withRestrictExpenditures(true);
+    createEntity(LEDGER.getEndpoint(), ledger, TENANT_HEADER);
+
+    var groupOne = new Group().withId(groupOneId).withCode("GRP1").withName("Group one").withStatus(Group.Status.ACTIVE);
+    createEntity(GROUP.getEndpoint(), groupOne, TENANT_HEADER);
+    var groupTwo = new Group().withId(groupTwoId).withCode("GRP2").withName("Group two").withStatus(Group.Status.ACTIVE);
+    createEntity(GROUP.getEndpoint(), groupTwo, TENANT_HEADER);
+
+    var groupedFund = new Fund()
+      .withId(groupedFundId).withCode("GFND").withName("Grouped fund")
+      .withLedgerId(ledgerId).withFundStatus(Fund.FundStatus.ACTIVE);
+    createEntity(FUND.getEndpoint(), groupedFund, TENANT_HEADER);
+
+    var ungroupedFund = new Fund()
+      .withId(ungroupedFundId).withCode("UFND").withName("Ungrouped fund")
+      .withLedgerId(ledgerId).withFundStatus(Fund.FundStatus.ACTIVE);
+    createEntity(FUND.getEndpoint(), ungroupedFund, TENANT_HEADER);
+
+    var groupedBudget = new Budget()
+      .withId(groupedBudgetId).withName("Grouped budget")
+      .withBudgetStatus(Budget.BudgetStatus.ACTIVE)
+      .withFiscalYearId(fiscalYearId).withFundId(groupedFundId)
+      .withInitialAllocation(1000.0);
+    createEntity(BUDGET.getEndpoint(), groupedBudget, TENANT_HEADER);
+
+    var ungroupedBudget = new Budget()
+      .withId(ungroupedBudgetId).withName("Ungrouped budget")
+      .withBudgetStatus(Budget.BudgetStatus.ACTIVE)
+      .withFiscalYearId(fiscalYearId).withFundId(ungroupedFundId)
+      .withInitialAllocation(500.0);
+    createEntity(BUDGET.getEndpoint(), ungroupedBudget, TENANT_HEADER);
+
+    var expenseClass = new ExpenseClass().withId(expenseClassId).withCode("PRINT").withName("Print");
+    createEntity(EXPENSE_CLASS.getEndpoint(), expenseClass, TENANT_HEADER);
+
+    var budgetExpenseClass = new BudgetExpenseClass()
+      .withBudgetId(groupedBudgetId).withExpenseClassId(expenseClassId)
+      .withStatus(BudgetExpenseClass.Status.ACTIVE);
+    createEntity(BUDGET_EXPENSE_CLASS.getEndpoint(), budgetExpenseClass, TENANT_HEADER);
+
+    createEntity(GROUP_FUND_FY.getEndpoint(),
+      new GroupFundFiscalYear().withGroupId(groupOneId).withFundId(groupedFundId).withFiscalYearId(fiscalYearId)
+        .withBudgetId(groupedBudgetId),
+      TENANT_HEADER);
+    createEntity(GROUP_FUND_FY.getEndpoint(),
+      new GroupFundFiscalYear().withGroupId(groupTwoId).withFundId(groupedFundId).withFiscalYearId(fiscalYearId)
+        .withBudgetId(groupedBudgetId),
+      TENANT_HEADER);
+
+    var response = getData(FISCAL_YEAR_HIERARCHY_ENDPOINT + "?fiscalYearId=" + fiscalYearId, TENANT_HEADER);
+    var body = response.getBody().as(FiscalYearHierarchyCollection.class);
+
+    assertEquals(1, body.getTotalRecords());
+    var hierarchy = body.getFiscalYearHierarchies().getFirst();
+    assertEquals(ledgerId, hierarchy.getLedgerId());
+    assertEquals(fiscalYearId, hierarchy.getFiscalYearId());
+
+    assertEquals(2, hierarchy.getGroups().size());
+    for (var group : hierarchy.getGroups()) {
+      assertEquals(1, group.getFunds().size());
+      var fund = group.getFunds().getFirst();
+      assertEquals(groupedFundId, fund.getFundId());
+      assertEquals(groupedBudgetId, fund.getFiscalYearHierarchyBudget().getBudgetId());
+      assertEquals(1, fund.getFiscalYearHierarchyBudget().getBudgetExpenseClasses().size());
+      assertEquals(expenseClassId, fund.getFiscalYearHierarchyBudget().getBudgetExpenseClasses().getFirst().getExpenseClassId());
+    }
+
+    assertEquals(1, hierarchy.getFunds().size());
+    var ungrouped = hierarchy.getFunds().getFirst();
+    assertEquals(ungroupedFundId, ungrouped.getFundId());
+    assertEquals(ungroupedBudgetId, ungrouped.getFiscalYearHierarchyBudget().getBudgetId());
+    assertTrue(ungrouped.getFiscalYearHierarchyBudget().getBudgetExpenseClasses().isEmpty());
+  }
+
+  @Test
+  public void negative_testMissingFiscalYearId() {
+    getData(FISCAL_YEAR_HIERARCHY_ENDPOINT, TENANT_HEADER)
+      .then()
+      .statusCode(400);
+  }
+
+}


### PR DESCRIPTION
Adds a read-only /finance-storage/fiscal-year-hierarchy endpoint that returns, for a given fiscal year, the ledger/group/fund/budget/budget-expense-class rollup as a nested tree, joined via a new DB view and assembled in Java. Bumps the acq-models submodule to pick up the merged FiscalYearHierarchy schema (folio-org/acq-models#576).

### **Purpose**

The finance UI needs a single call that returns the full ledger -> group -> fund -> budget -> budget expense class rollup for a fiscal year, instead of making separate calls for each entity and stitching the tree together client-side.

https://folio-org.atlassian.net/browse/MODFISTO-506

### **Approach**

- `fiscal_year_hierarchy_view.sql`: a new DB view joining `ledger`, `fund`, `budget` (LEFT), `group_fund_fiscal_year` (LEFT), and `groups` (LEFT), using the same fiscal-year `series` join `all_finance_data_view.sql` already relies on. Nests `budgetExpenseClasses` as a `jsonb_agg` array per row directly in SQL, since that's a clean 1:many relationship. Registered in `schema.json`'s `scripts` array.
- A fund can belong to more than one group for a given fiscal year (via `group_fund_fiscal_year`) - the view intentionally returns one row per (ledger, group, fund, budget) combination, so a fund appears once per group it's in for that year; ungrouped funds get exactly one row with a null group.
- `FiscalYearHierarchyPostgresDAO` queries that view for a given `fiscalYearId` and assembles the flat rows into the nested Ledger -> Group -> Fund -> Budget tree in Java (grouping, not more SQL nesting) - simpler to read/test than deeper correlated subqueries, and explicitly allowed by the ticket given the expected data volume per fiscal year is small.
- `FiscalYearHierarchyApi` wires the DAO to the generated REST resource; `GET /finance-storage/fiscal-year-hierarchy?fiscalYearId={uuid}` returns a `FiscalYearHierarchyCollection` (one entry per ledger). Used a plain required query parameter rather than the usual RMB CQL `query=`/`pageable` pattern, since this endpoint does its own SQL + tree assembly rather than going through RMB's generic CQL-over-view machinery, and a hierarchy is inherently scoped to exactly one fiscal year.
- New `finance-storage.fiscal-year-hierarchy.collection.get`/`.all` permissions registered in the ModuleDescriptor.

---

### **Pre-Review Checklist**

- [x] **Self-reviewed Code** — Reviewed code for issues, unnecessary parts, and overall quality.
- [ ] **Testing** — `FiscalYearHierarchyApiTest` is included and covers the multi-group-per-fund and ungrouped-fund tree shapes, but Im having trouble running it against a real Postgres/Okapi stack. 
- [x] **Logging**: No endpoint-specific logging added; errors flow through the existing shared `buildErrorResponse`/`HttpException` handling, consistent with the similar `TransactionTotalApi`/`FinanceDataApi` endpoints.
- [x] **Breaking Changes** — Purely additive; no existing endpoints, schemas, or DB objects were modified.
  - [x] API/schema changes — new `FiscalYearHierarchy`/`FiscalYearHierarchyCollection` schemas (acq-models #576, already merged)
  - [x] Interface version updates — new `finance-storage.fiscal-year-hierarchy` v1.0 interface added
  - [x] DB schema changes / migration scripts — new `fiscal_year_hierarchy_view` (view only, no table/migration changes)
- [x] **New Properties / Environment Variables** — N/A, no new configuration or environment variables introduced.
